### PR TITLE
Claude/switch arbitrage branch 01 wx8 n4ium hq4mv tn juy6v m1

### DIFF
--- a/hummingbot/strategy/arbitrage_l/arbitrage.pxd
+++ b/hummingbot/strategy/arbitrage_l/arbitrage.pxd
@@ -47,16 +47,10 @@ cdef class ArbitrageLStrategy(StrategyBase):
         double _cached_quote_rate
         double _last_rate_update
         
-        # Buy-in params/state
-        bint _buy_in_enabled
-        double _buy_in_target_usd
-        double _buy_in_min_profitability
-        bint _buy_in_completed
-        # Pending buy-in tracking
-        dict _pending_buyin_by_asset
-        dict _pending_buyin_orders
-        
-        
+        # Buy-in handler (None when disabled)
+        object _buy_in_handler
+
+
         # Order tracking - single unified map
         unordered_map[string, double] _order_timestamps
         # Track completed orders to avoid duplicate completion logging
@@ -80,6 +74,10 @@ cdef class ArbitrageLStrategy(StrategyBase):
     cdef bint c_check_markets_ready_orchestrated(self)
     cdef bint c_ready_for_new_orders(self, list market_tuples)
     cdef string _to_cpp_str(self, object py_str)
+
+    # Helper methods
+    cdef object c_safe_quantize_order_amount(self, object market, str trading_pair, object amount, object price)
+    cdef void c_remove_pending_order(self, object market_tuple, str order_id, str context)
     
     # Conversion rate methods
     cdef double _conv_rate(self, object buy_market_tuple, object sell_market_tuple)
@@ -92,28 +90,16 @@ cdef class ArbitrageLStrategy(StrategyBase):
     
     # Trading logic
     cdef double c_get_reference_bid_for_asset(self, str asset_key)
-    cdef bint c_handle_buy_in(self, object buy_market_tuple, object sell_market_tuple)
     cdef tuple c_find_best_buyin_amount(self,
                                         object buy_market_tuple,
                                         object sell_market_tuple,
                                         double buy_quote_balance,
-                                        double max_spend_quote)
-    cdef void c_maybe_disable_buy_in(self)
-    cdef void c_scan_and_mark_buyin_completion(self)
+                                        double max_spend_quote,
+                                        double min_profitability)
     cdef pair[int, double] c_top_of_book_profitable_get_conv(self,
                                                              object buy_market_tuple,
                                                              object sell_market_tuple,
                                                              double min_profitability)
-    cdef pair[double, double] c_compute_value_and_shortfall(self,
-                                                            double base_balance,
-                                                            double last_bid)
-    cdef double c_get_aggregated_base_balance(self, str asset)
-    cdef double c_get_pending_buyin_base(self, str asset)
-    cdef double c_get_adjusted_base_balance(self, str asset)
-    cdef bint c_try_mark_complete_buy_in(self,
-                                         str pair,
-                                         double current_value_quote,
-                                         double shortfall)
     cdef pair[double, double] c_calculate_profitability(self, object market_pair)
     cdef c_execute_arbitrage(self, object buy_market_tuple, object sell_market_tuple)
     cdef tuple c_find_best_profitable_amount(self, object buy_market_tuple, object sell_market_tuple)

--- a/hummingbot/strategy/arbitrage_l/arbitrage.pyx
+++ b/hummingbot/strategy/arbitrage_l/arbitrage.pyx
@@ -34,6 +34,7 @@ from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 from hummingbot.strategy.arbitrage_l.arbitrage_config_map import arbitrage_l_config_map
 from hummingbot.core.data_type.order_book cimport OrderBook
 from hummingbot.core.data_type.OrderBookEntry cimport OrderBookEntry
+from hummingbot.strategy.arbitrage_l.buy_in_handler cimport ArbitrageBuyInHandler
 
 # Constants - Now configurable via init_params
 cdef:
@@ -69,8 +70,7 @@ cdef class ArbitrageLStrategy(StrategyBase):
         # Initialize defaults so attributes exist even if init_params isn't called yet
         self._last_global_trade_timestamp = 0.0
         self._last_failure_timestamps = {}
-        self._pending_buyin_by_asset = {}
-        self._pending_buyin_orders = {}
+        self._buy_in_handler = None  # Will be initialized in init_params if enabled
         # Track whether a given order_id has received any fill events
         self._orders_with_fills = set()
         # Keep recent order -> market pair mapping for late events
@@ -91,11 +91,6 @@ cdef class ArbitrageLStrategy(StrategyBase):
         self._last_rate_update = 0
         # Orchestrated mode flag (for multi-strategy orchestrator optimization)
         self._orchestrated_mode = False
-        # Buy-in params/state - initialize defaults
-        self._buy_in_enabled = False
-        self._buy_in_target_usd = 100.0
-        self._buy_in_min_profitability = 0.005
-        self._buy_in_completed = False
 
     def init_params(self,
                     market_pairs: List[ArbitrageLMarketPair],
@@ -183,15 +178,12 @@ cdef class ArbitrageLStrategy(StrategyBase):
         except Exception:
             pass
 
-        # Buy-in params/state
-        self._buy_in_enabled = buy_in_enabled
-        self._buy_in_target_usd = buy_in_target_usd
-        self._buy_in_min_profitability = buy_in_min_profitability
-        self._buy_in_completed = False
-        # Pending buy-in tracking (asset -> base amount) and per-order map (order_id -> (asset, amount))
-        # Used to de-stale holdings valuation until fills settle
-        self._pending_buyin_by_asset = {}
-        self._pending_buyin_orders = {}
+        # Buy-in handler (only create if enabled to avoid overhead)
+        if buy_in_enabled:
+            self._buy_in_handler = ArbitrageBuyInHandler(
+                self, buy_in_enabled, buy_in_target_usd, buy_in_min_profitability)
+        else:
+            self._buy_in_handler = None
 
         # Orchestration mode (for multi-strategy orchestrator optimization)
         self._orchestrated_mode = orchestrated_mode
@@ -461,36 +453,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
                 lines.append(
                     f"    best: buy-{best_pair.first.market.name} sell-{best_pair.second.market.name} -> {best_prof * 100:+.4f}%")
 
-            # Buy-in status (aggregate per base asset across active markets)
-            if self._buy_in_enabled:
-                # Collect base assets from active market pairs (no unique tuple logic)
-                try:
-                    aset = set()
-                    for mp in self._market_pairs:
-                        aset.add(mp.first.base_asset)
-                        aset.add(mp.second.base_asset)
-                    base_assets = sorted(aset)
-                except Exception:
-                    base_assets = []
-                agg_lines = []
-                any_pending = False
-                for a in base_assets:
-                    # Get a reference bid from any active tuple with this base asset
-                    bid = self.c_get_reference_bid_for_asset(a)
-                    # Aggregate available base balance using the same source as the Assets table (no fallback)
-                    total_base = 0.0
-                    for t in unique_tuples:
-                        if t.base_asset == a:
-                            total_base += float(balance_map.get((t.market.name, a), 0.0))
-                    total_value = total_base * bid
-                    # Status should reflect the permanent global flag, not current valuation
-                    is_pending = (not self._buy_in_completed)
-                    if is_pending:
-                        any_pending = True
-                    agg_lines.append(f"    {a}: base={total_base:.6f} value={total_value:.6f} ({'pending' if is_pending else 'completed'})")
-                if any_pending and self._buy_in_enabled:
-                    lines.extend(["", f"  Buy-in: target={self._buy_in_target_usd:.6f} min_prof={self._buy_in_min_profitability * 100:.2f}%"]) 
-                    lines.extend(agg_lines)
+            # Buy-in status (delegate to handler)
+            if self._buy_in_handler is not None:
+                lines.extend(self._buy_in_handler.get_status_lines(unique_tuples, balance_map))
 
             # Pending orders
             if self.tracked_limit_orders or self.tracked_market_orders:
@@ -538,8 +503,8 @@ cdef class ArbitrageLStrategy(StrategyBase):
                 # Mark ready and do one-time buy-in check if not done yet
                 if not self._all_markets_ready:
                     self._all_markets_ready = True
-                    if self._buy_in_enabled:
-                        self.c_scan_and_mark_buyin_completion()
+                    if self._buy_in_handler is not None:
+                        self._buy_in_handler.c_scan_and_mark_completion()
 
             # Early check: skip orderbook scanning if global cooldown is active
             # This optimization avoids expensive orderbook iterations when we can't trade anyway
@@ -568,38 +533,33 @@ cdef class ArbitrageLStrategy(StrategyBase):
 
             # Execute only the globally best profitable opportunity
             if best_buy is not None and best_sell is not None and best_profitability >= self._min_profitability:
-                if self._buy_in_enabled:
-                    # Quick skip if buy-in already completed
-                    if not self._buy_in_completed:
-                        if self.c_handle_buy_in(best_buy, best_sell):
-                            # buy-in executed; skip regular arbitrage this tick
-                            pass
-                        else:
-                            self.c_execute_arbitrage(best_buy, best_sell)
+                if self._buy_in_handler is not None and self._buy_in_handler.is_active:
+                    # Try buy-in first if not completed
+                    if self._buy_in_handler.c_handle_buy_in(best_buy, best_sell):
+                        # buy-in executed; skip regular arbitrage this tick
+                        pass
                     else:
                         self.c_execute_arbitrage(best_buy, best_sell)
                 else:
                     self.c_execute_arbitrage(best_buy, best_sell)
-            elif self._buy_in_enabled and best_buy is not None and best_sell is not None:
+            elif self._buy_in_handler is not None and self._buy_in_handler.is_active and best_buy is not None and best_sell is not None:
                 # Not enough edge for normal arbitrage. Still try buy-in using its own threshold,
                 # and also try the reversed pairing in case that direction offers cheaper buys.
-                if not self._buy_in_completed:
-                    # Attempt with current best direction (respect pending/cool-off)
-                    placed_buyin = False
-                    if self.c_ready_for_new_orders([best_buy, best_sell]) and self.c_books_ready_for_direction(best_buy, best_sell):
-                        placed_buyin = self.c_handle_buy_in(best_buy, best_sell) or False
-                    # Also attempt reversed only if nothing was placed in current direction
-                    if (not placed_buyin) and (not self._buy_in_completed):
-                        if self.c_ready_for_new_orders([best_sell, best_buy]) and self.c_books_ready_for_direction(best_sell, best_buy):
-                            self.c_handle_buy_in(best_sell, best_buy)
-            elif self._buy_in_enabled and best_buy is None:
+                # Attempt with current best direction (respect pending/cool-off)
+                placed_buyin = False
+                if self.c_ready_for_new_orders([best_buy, best_sell]) and self.c_books_ready_for_direction(best_buy, best_sell):
+                    placed_buyin = self._buy_in_handler.c_handle_buy_in(best_buy, best_sell) or False
+                # Also attempt reversed only if nothing was placed in current direction
+                if (not placed_buyin) and self._buy_in_handler.is_active:
+                    if self.c_ready_for_new_orders([best_sell, best_buy]) and self.c_books_ready_for_direction(best_sell, best_buy):
+                        self._buy_in_handler.c_handle_buy_in(best_sell, best_buy)
+            elif self._buy_in_handler is not None and self._buy_in_handler.is_active and best_buy is None:
                 # No arbitrageable pair found (likely due to zero sell-side base). Proactively scan all ordered
                 # pairs to try buy-in on any asset/venue where shortfall and edge allow it.
-                if not self._buy_in_completed:
-                    for market_pair in self._market_pairs:
-                        if self.c_ready_for_new_orders([market_pair.first, market_pair.second]) and self.c_books_ready_for_direction(market_pair.first, market_pair.second):
-                            if self.c_handle_buy_in(market_pair.first, market_pair.second):
-                                break
+                for market_pair in self._market_pairs:
+                    if self.c_ready_for_new_orders([market_pair.first, market_pair.second]) and self.c_books_ready_for_direction(market_pair.first, market_pair.second):
+                        if self._buy_in_handler.c_handle_buy_in(market_pair.first, market_pair.second):
+                            break
 
             # Check ALL pending orders for timeouts every tick
             # This ensures canceled orders are detected even if their market is no longer being considered
@@ -632,9 +592,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
                     # Debounce status logs for a short window to let connectors settle
                     self._status_debounce_until = self._current_timestamp + 2.0
                 # Run one-time global buy-in completion check now that markets are ready (always log once)
-                if self._buy_in_enabled:
+                if self._buy_in_handler is not None:
                     self.log_with_clock(logging.INFO, "Buy-in config enabled at startup; performing completion check.")
-                    self.c_scan_and_mark_buyin_completion()
+                    self._buy_in_handler.c_scan_and_mark_completion()
                 else:
                     self.log_with_clock(logging.INFO, "Buy-in config disabled at startup.")
         
@@ -751,9 +711,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
                     logging.DEBUG,
                     f"{order_type} order completed on {market_pair_tuple[0].name}: {order_id}")
 
-            # TODO: Buy-in cleanup to be moved to helper script
-            # Placeholder for buy-in pending order cleanup on completion
-            pass
+            # Cleanup buy-in tracking (delegated to handler)
+            if self._buy_in_handler is not None:
+                self._buy_in_handler.handle_order_completion(order_id, is_buy)
 
         except Exception as e:
             self.logger().error(f"Error handling {order_type.lower()} order completion: {e}", exc_info=True)
@@ -816,9 +776,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
             pass
         self._sb_order_tracker.c_stop_tracking_limit_order(market_pair, order_id)
 
-        # TODO: Buy-in cleanup to be moved to helper script
-        # Placeholder for buy-in pending order cleanup on cancellation
-        pass
+        # Cleanup buy-in tracking (delegated to handler)
+        if self._buy_in_handler is not None:
+            self._buy_in_handler.handle_order_cancellation(order_id)
 
         # Remove from pending orders tracking - check both buy and sell dicts
         self.c_remove_pending_order(market_pair, order_id, "cancelled")
@@ -925,9 +885,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
                             pass
                         self._sb_order_tracker.c_stop_tracking_limit_order(market_tuple, order_id)
 
-                        # TODO: Buy-in cleanup to be moved to helper script
-                        # Placeholder for buy-in pending order cleanup on timeout
-                        pass
+                        # Cleanup buy-in tracking (delegated to handler)
+                        if self._buy_in_handler is not None:
+                            self._buy_in_handler.handle_order_timeout(order_id)
 
                         # Remove from pending orders tracking - check both buy and sell dicts
                         self.c_remove_pending_order(market_tuple, order_id, "")
@@ -1405,258 +1365,13 @@ cdef class ArbitrageLStrategy(StrategyBase):
  
  
  
-    cdef void c_maybe_disable_buy_in(self):
-        """Disable buy-in globally for this run once target is reached (do not mutate config)."""
-        if self._buy_in_completed and self._buy_in_enabled:
-            self._buy_in_enabled = False
-            if self._logging_options & self.OPTION_LOG_STATUS_REPORT:
-                self.log_with_clock(logging.INFO, "Buy-in completed. Disabling buy-in for this session.")
-
-    cdef void c_scan_and_mark_buyin_completion(self):
-        """Re-evaluate the base asset against target and disable buy-in when done."""
-        if not self._buy_in_enabled or self._buy_in_completed:
-            return
-        cdef:
-            str asset_key
-            double last_bid = 0.0
-            double base_bal
-            pair[double, double] val_short
-            double current_value_quote
-            double shortfall
-            list unique_tuples
-            object assets_df
-            dict balance_map
-        # Determine the single base asset from the first market pair
-        asset_key = self._market_pairs[0].first.base_asset
-        # Get a non-zero bid from any active tuple with this base asset
-        last_bid = self.c_get_reference_bid_for_asset(asset_key)
-        # Build balances from the same source as status for consistency (shared helper)
-        unique_tuples, assets_df, balance_map = self.c_build_unique_tuples_assets_and_balance_map()
-        # Sum base using the same map
-        base_bal = 0.0
-        for t in unique_tuples:
-            if t.base_asset == asset_key:
-                base_bal += float(balance_map.get((t.market.name, asset_key), 0.0))
-        # Include any in-flight buy-in base to avoid stale underestimation
-        base_bal += self.c_get_pending_buyin_base(asset_key)
-        val_short = self.c_compute_value_and_shortfall(base_bal, last_bid)
-        current_value_quote = val_short.first
-        shortfall = val_short.second
-        # Concise info log about startup buy-in state and decision
-        try:
-            decision = "disable" if (current_value_quote >= self._buy_in_target_usd or (shortfall > 0 and shortfall < self._min_order_usd)) else "keep"
-            self.log_with_clock(
-                logging.INFO,
-                f"Buy-in check: asset={asset_key} base={base_bal:.6f} bid={last_bid:.6f} value={current_value_quote:.6f} target={self._buy_in_target_usd:.6f} -> {decision}")
-        except Exception:
-            pass
-        if self.c_try_mark_complete_buy_in(asset_key, current_value_quote, shortfall):
-            pass
-        self.c_maybe_disable_buy_in()
-
-    cdef pair[double, double] c_compute_value_and_shortfall(self,
-                                                           double base_balance,
-                                                           double last_bid):
-        """Return (current_value_quote, shortfall)."""
-        cdef double current_value_quote = base_balance * last_bid
-        cdef double shortfall = 0.0
-        if current_value_quote < self._buy_in_target_usd:
-            shortfall = self._buy_in_target_usd - current_value_quote
-        else:
-            shortfall = 0.0
-        return pair[double, double](current_value_quote, shortfall)
-
-    cdef double c_get_aggregated_base_balance(self, str asset):
-        """Aggregate base balance consistently using the same source as startup status (assets_df/balance_map)."""
-        cdef:
-            double total = 0.0
-            list unique_tuples
-            object assets_df
-            dict balance_map
-            object t
-        try:
-            unique_tuples, assets_df, balance_map = self.c_build_unique_tuples_assets_and_balance_map()
-            for t in unique_tuples:
-                if t.base_asset == asset:
-                    total += float(balance_map.get((t.market.name, asset), 0.0))
-        except Exception:
-            return 0.0
-        return total
-
-    cdef double c_get_pending_buyin_base(self, str asset):
-        """Return in-flight buy-in base amount for asset (orders placed but not yet reflected in balances)."""
-        try:
-            return <double> self._pending_buyin_by_asset.get(asset, 0.0)
-        except Exception:
-            return 0.0
-
-    cdef double c_get_adjusted_base_balance(self, str asset):
-        """Aggregated base balance plus pending buy-in base (to avoid stale underestimation)."""
-        cdef double agg = self.c_get_aggregated_base_balance(asset)
-        cdef double pend = self.c_get_pending_buyin_base(asset)
-        return agg + pend
-
-    cdef bint c_try_mark_complete_buy_in(self,
-                                         str pair,
-                                         double current_value_quote,
-                                         double shortfall):
-        """Mark buy-in as completed if at target or remaining < min notional (single asset)."""
-        if current_value_quote >= self._buy_in_target_usd:
-            self._buy_in_completed = True
-            self.c_maybe_disable_buy_in()
-            return True
-        if shortfall > 0 and shortfall < self._min_order_usd:
-            self._buy_in_completed = True
-            if self._logging_options & self.OPTION_LOG_STATUS_REPORT:
-                self.log_with_clock(logging.INFO, f"Buy-in considered complete on {pair}: shortfall {shortfall:.6f} < min notional {self._min_order_usd:.6f}")
-            self.c_maybe_disable_buy_in()
-            return True
-        return False
-
-    cdef bint c_handle_buy_in(self, object buy_market_tuple, object sell_market_tuple):
-        """
-        If base asset holdings on buy_market_tuple are below target (in that market's quote units), place a taker buy
-        using the same amount-finding logic as arbitrage execution, gated by a separate buy-in profitability.
-        Returns True if a buy-in was placed; False otherwise.
-        """
-        # CRITICAL SAFEGUARD: Prevent double execution at the same timestamp
-        # This protects against multiple strategy instances or rapid tick cycles
-        if self._last_global_trade_timestamp == self._current_timestamp:
-            self.logger().debug(
-                f"Skipping duplicate buy-in execution at timestamp {self._current_timestamp:.3f} "
-                f"(already executed this tick)")
-            return False
-
-        # CRITICAL: Set timestamp IMMEDIATELY to prevent race condition
-        # If we wait until later, a second call could slip through the check above
-        self._last_global_trade_timestamp = self._current_timestamp
-
-        if not self._buy_in_enabled:
-            return False
-        cdef:
-            str pair_str = buy_market_tuple.trading_pair
-            ExchangeBase market = buy_market_tuple.market #object market = buy_market_tuple.market
-            double base_bal = 0.0
-            double quote_bal = float(market.c_get_available_balance(buy_market_tuple.quote_asset))
-            double best_amount
-            double best_prof
-            double sell_price
-            double buy_price
-            tuple res
-            str asset_key = buy_market_tuple.base_asset
-
-        if self._buy_in_completed:
-            return False
-
-        # Evaluate progress vs target and early complete (aggregate base across all markets)
-        # Get a reliable bid for the asset from any active tuple to avoid zero-bid stalls
-        cdef double last_bid = self.c_get_reference_bid_for_asset(asset_key)
-        base_bal = self.c_get_adjusted_base_balance(asset_key)
-        cdef pair[double, double] val_short = self.c_compute_value_and_shortfall(base_bal, last_bid)
-        cdef double current_value_quote = val_short.first
-        cdef double shortfall = val_short.second
-        if self.c_try_mark_complete_buy_in(pair_str, current_value_quote, shortfall):
-            return False
-
-        # Require quote balance to spend and a minimal edge
-        if quote_bal <= 0:
-            return False
-
-        res = self.c_find_best_buyin_amount(
-            buy_market_tuple,
-            sell_market_tuple,
-            quote_bal,
-            shortfall
-        )
-        best_amount = <double>res[0]
-        best_prof = <double>res[1]
-        sell_price = <double>res[2]
-        buy_price = <double>res[3]
-
-        if best_amount <= 0 or best_prof < self._buy_in_min_profitability:
-            return False
-
-        # Place only the buy leg on buy market
-        cdef object order_type = OrderType.LIMIT
-        cdef object quantized_amount
-        cdef object dec_safe_amount2 = Decimal(str(max(0.0, best_amount - QUANTIZATION_EPSILON)))
-        quantized_amount = self.c_safe_quantize_order_amount(market, buy_market_tuple.trading_pair, dec_safe_amount2, Decimal(str(buy_price)))
-        # Ensure not exceeding available quote after quantization
-        cdef double max_affordable = 0.0
-        if buy_price > 0:
-            max_affordable = quote_bal / buy_price
-        if float(quantized_amount) > max_affordable:
-            quantized_amount = self.c_safe_quantize_order_amount(market, buy_market_tuple.trading_pair, Decimal(str(max(0.0, max_affordable - QUANTIZATION_EPSILON))), Decimal(str(buy_price)))
-        if quantized_amount <= Decimal("0"):
-            return False
-
-        # Apply max_order_size cap from trading rules 
-        try:
-            buy_trading_rule = market._trading_rules.get(buy_market_tuple.trading_pair)
-            if buy_trading_rule is not None and buy_trading_rule.max_order_size > Decimal("0"):
-                if quantized_amount > buy_trading_rule.max_order_size:
-                    quantized_amount = min(quantized_amount, buy_trading_rule.max_order_size)
-        except Exception:
-            pass  # Fail gracefully if trading rules unavailable
-
-        # Enforce minimum notional like normal arbitrage orders
-        # NOTE: volume_usd is notional value in buy market quote currency, not necessarily USD
-        cdef double volume_usd = float(quantized_amount) * buy_price
-        if volume_usd < self._min_order_usd:
-            # If we cannot place a valid minimum-size order, mark complete only if remaining shortfall is under min
-            if self.c_try_mark_complete_buy_in(pair_str, current_value_quote, shortfall):
-                return False
-            return False
-
-        try:
-            buy_order_id = self.c_buy_with_specific_market(
-                buy_market_tuple,
-                quantized_amount,
-                order_type=order_type,
-                price=Decimal(str(buy_price)),
-                expiration_seconds=self._next_trade_delay)
-        except Exception as e:
-            # CRITICAL: Set failure timestamp to enforce cooldown
-            self._last_failure_timestamps[buy_market_tuple] = self._current_timestamp
-            self.logger().warning(f"Error submitting buy-in order to {market.name}: {e}")
-            return False
-
-        # Track order timestamp for housekeeping
-        cdef string buy_id_str = self._to_cpp_str(buy_order_id)
-        self._order_timestamps[buy_id_str] = self._current_timestamp
-
-        # Track pending BUY order for buy-in (buy-in is always a buy order)
-        try:
-            if buy_market_tuple not in self._pending_buy_orders_by_market:
-                self._pending_buy_orders_by_market[buy_market_tuple] = set()
-            self._pending_buy_orders_by_market[buy_market_tuple].add(buy_order_id)
-        except Exception as e:
-            self.logger().warning(f"Failed to track pending buy-in order by market: {e}")
-
-        # Track pending base to avoid stale underestimation until fills settle
-        try:
-            self._pending_buyin_orders[buy_order_id] = (asset_key, float(quantized_amount))
-            self._pending_buyin_by_asset[asset_key] = float(self._pending_buyin_by_asset.get(asset_key, 0.0)) + float(quantized_amount)
-        except Exception as e:
-            self.logger().warning(f"Failed to track pending buy-in for order {buy_order_id}: {e}")
-
-        # Check if target reached after placing (aggregate across all markets)
-        # Use the same reliable bid lookup as above
-        last_bid = self.c_get_reference_bid_for_asset(asset_key)
-        base_bal = self.c_get_adjusted_base_balance(asset_key)
-        val_short = self.c_compute_value_and_shortfall(base_bal, last_bid)
-        current_value_quote = val_short.first
-        shortfall = val_short.second
-        if self.c_try_mark_complete_buy_in(pair_str, current_value_quote, shortfall):
-            self.c_maybe_disable_buy_in()
-
-        return True
 
     cdef tuple c_find_best_buyin_amount(self,
                                         object buy_market_tuple,
                                         object sell_market_tuple,
                                         double buy_quote_balance,
-                                        double max_spend_quote):
+                                        double max_spend_quote,
+                                        double min_profitability):
         """
         Compute best buy-only amount using cross-market price edge, ignoring sell-side base balance limits.
         Caps spend by both available quote balance and provided max_spend_quote.
@@ -1670,7 +1385,7 @@ cdef class ArbitrageLStrategy(StrategyBase):
             return (0.0, 0.0, 0.0, 0.0)
 
         # Early uniform gate for buy-in; reuse conv_rate
-        gate_res2 = self.c_top_of_book_profitable_get_conv(buy_market_tuple, sell_market_tuple, self._buy_in_min_profitability)
+        gate_res2 = self.c_top_of_book_profitable_get_conv(buy_market_tuple, sell_market_tuple, min_profitability)
         if not gate_res2.first:
             return (0.0, 0.0, 0.0, 0.0)
         conv_rate = gate_res2.second
@@ -1696,7 +1411,7 @@ cdef class ArbitrageLStrategy(StrategyBase):
 
         # Use buy-in profitability threshold here (not the main arbitrage threshold), with capacity-aware early-stop
         profitable_orders = c_find_profitable_arbitrage_orders(
-            self._buy_in_min_profitability,
+            min_profitability,
             buy_market_tuple,
             sell_market_tuple,
             1.0,
@@ -1771,9 +1486,13 @@ cdef class ArbitrageLStrategy(StrategyBase):
             # Also remove from completed orders set
             self._completed_orders.erase(order_id_str)
 
-            # TODO: Buy-in cleanup to be moved to helper script
-            # Placeholder for buy-in pending order cleanup during old order cleanup
-            pass
+            # Cleanup buy-in tracking (delegated to handler)
+            try:
+                oid = order_id_str.decode('utf-8')
+                if self._buy_in_handler is not None and oid is not None:
+                    self._buy_in_handler.handle_old_order_cleanup(oid)
+            except Exception:
+                pass
         
         # Warn if too many tracked orders
         if self._order_timestamps.size() > self._max_tracked_orders:

--- a/hummingbot/strategy/arbitrage_l/arbitrage.pyx
+++ b/hummingbot/strategy/arbitrage_l/arbitrage.pyx
@@ -242,6 +242,49 @@ cdef class ArbitrageLStrategy(StrategyBase):
             return 1.0
         return self.c_get_market_to_market_conversion_rate(buy_market_tuple, sell_market_tuple)
 
+    cdef object c_safe_quantize_order_amount(self,
+                                              ExchangeBase market,
+                                              str trading_pair,
+                                              object amount,
+                                              object price):
+        """
+        Safe quantization with fallback.
+        Tries c_quantize_order_amount with price, falls back to quantize_order_amount without price.
+        """
+        try:
+            return market.c_quantize_order_amount(trading_pair, amount, price)
+        except Exception:
+            return market.quantize_order_amount(trading_pair, amount)
+
+    cdef void c_remove_pending_order(self, object market_tuple, str order_id, str context="order"):
+        """
+        Remove order from pending buy/sell order tracking.
+        Checks both pending buy and sell dicts and cleans up empty entries.
+
+        Args:
+            market_tuple: Market pair tuple to remove order from
+            order_id: Order ID to remove
+            context: Context string for error logging (e.g., "completed", "cancelled")
+        """
+        try:
+            if market_tuple is not None:
+                # Try removing from pending buy orders
+                pending_buys = self._pending_buy_orders_by_market.get(market_tuple)
+                if pending_buys is not None and order_id in pending_buys:
+                    pending_buys.discard(order_id)
+                    if len(pending_buys) == 0:
+                        self._pending_buy_orders_by_market.pop(market_tuple, None)
+
+                # Try removing from pending sell orders
+                pending_sells = self._pending_sell_orders_by_market.get(market_tuple)
+                if pending_sells is not None and order_id in pending_sells:
+                    pending_sells.discard(order_id)
+                    if len(pending_sells) == 0:
+                        self._pending_sell_orders_by_market.pop(market_tuple, None)
+        except Exception as e:
+            if context:
+                self.logger().warning(f"Failed to remove {context} order from pending tracking: {e}")
+
     cdef double c_get_conversion_rate(self, bint is_base_asset):
         """Get conversion rate for base or quote asset"""
         if not self._use_oracle_conversion_rate:
@@ -692,23 +735,7 @@ cdef class ArbitrageLStrategy(StrategyBase):
                 self.logger().info(f"Completion detected for {order_id} - removing cooldown on {cooldown_tuple[0].name}")
 
             # Remove from pending orders - check both buy and sell dicts
-            try:
-                if market_pair_tuple is not None:
-                    # Try removing from pending buy orders
-                    pending_buys = self._pending_buy_orders_by_market.get(market_pair_tuple)
-                    if pending_buys is not None and order_id in pending_buys:
-                        pending_buys.discard(order_id)
-                        if len(pending_buys) == 0:
-                            self._pending_buy_orders_by_market.pop(market_pair_tuple, None)
-
-                    # Try removing from pending sell orders
-                    pending_sells = self._pending_sell_orders_by_market.get(market_pair_tuple)
-                    if pending_sells is not None and order_id in pending_sells:
-                        pending_sells.discard(order_id)
-                        if len(pending_sells) == 0:
-                            self._pending_sell_orders_by_market.pop(market_pair_tuple, None)
-            except Exception as e:
-                self.logger().warning(f"Failed to remove completed order from pending tracking: {e}")
+            self.c_remove_pending_order(market_pair_tuple, order_id, "completed")
 
             # Check completion time - safely handle None market_pair_tuple
             if self._order_timestamps.find(order_id_str) != self._order_timestamps.end():
@@ -724,17 +751,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
                     logging.DEBUG,
                     f"{order_type} order completed on {market_pair_tuple[0].name}: {order_id}")
 
-            # If this was a buy-in buy order, remove its pending base from tracking
-            if is_buy:
-                try:
-                    pend = self._pending_buyin_orders.pop(order_id, None)
-                    if pend is not None:
-                        asset_key, amt = pend
-                        self._pending_buyin_by_asset[asset_key] = max(0.0, float(self._pending_buyin_by_asset.get(asset_key, 0.0)) - float(amt))
-                        if self._pending_buyin_by_asset.get(asset_key, 0.0) <= 1e-15:
-                            self._pending_buyin_by_asset.pop(asset_key, None)
-                except Exception:
-                    pass
+            # TODO: Buy-in cleanup to be moved to helper script
+            # Placeholder for buy-in pending order cleanup on completion
+            pass
 
         except Exception as e:
             self.logger().error(f"Error handling {order_type.lower()} order completion: {e}", exc_info=True)
@@ -797,38 +816,12 @@ cdef class ArbitrageLStrategy(StrategyBase):
             pass
         self._sb_order_tracker.c_stop_tracking_limit_order(market_pair, order_id)
 
-        # Clean up pending buy-in tracking if applicable
-        try:
-            pend = self._pending_buyin_orders.pop(order_id, None)
-            if pend is not None:
-                asset_key, amt = pend
-                self._pending_buyin_by_asset[asset_key] = max(
-                    0.0,
-                    float(self._pending_buyin_by_asset.get(asset_key, 0.0)) - float(amt)
-                )
-                if self._pending_buyin_by_asset.get(asset_key, 0.0) <= 1e-15:
-                    self._pending_buyin_by_asset.pop(asset_key, None)
-        except Exception:
-            pass
+        # TODO: Buy-in cleanup to be moved to helper script
+        # Placeholder for buy-in pending order cleanup on cancellation
+        pass
 
         # Remove from pending orders tracking - check both buy and sell dicts
-        try:
-            if market_pair is not None:
-                # Try removing from pending buy orders
-                pending_buys = self._pending_buy_orders_by_market.get(market_pair)
-                if pending_buys is not None and order_id in pending_buys:
-                    pending_buys.discard(order_id)
-                    if len(pending_buys) == 0:
-                        self._pending_buy_orders_by_market.pop(market_pair, None)
-
-                # Try removing from pending sell orders
-                pending_sells = self._pending_sell_orders_by_market.get(market_pair)
-                if pending_sells is not None and order_id in pending_sells:
-                    pending_sells.discard(order_id)
-                    if len(pending_sells) == 0:
-                        self._pending_sell_orders_by_market.pop(market_pair, None)
-        except Exception as e:
-            self.logger().warning(f"Failed to remove cancelled order from pending tracking: {e}")
+        self.c_remove_pending_order(market_pair, order_id, "cancelled")
 
         # Decide cooldown/logging based on completion status and cancellation reason
         if was_already_completed:
@@ -932,37 +925,12 @@ cdef class ArbitrageLStrategy(StrategyBase):
                             pass
                         self._sb_order_tracker.c_stop_tracking_limit_order(market_tuple, order_id)
 
-                        # Clean up pending buy-in tracking if applicable
-                        try:
-                            pend = self._pending_buyin_orders.pop(order_id, None)
-                            if pend is not None:
-                                asset_key, amt = pend
-                                self._pending_buyin_by_asset[asset_key] = max(
-                                    0.0,
-                                    float(self._pending_buyin_by_asset.get(asset_key, 0.0)) - float(amt)
-                                )
-                                if self._pending_buyin_by_asset.get(asset_key, 0.0) <= 1e-15:
-                                    self._pending_buyin_by_asset.pop(asset_key, None)
-                        except Exception:
-                            pass
+                        # TODO: Buy-in cleanup to be moved to helper script
+                        # Placeholder for buy-in pending order cleanup on timeout
+                        pass
 
                         # Remove from pending orders tracking - check both buy and sell dicts
-                        try:
-                            # Try removing from pending buy orders
-                            pending_buys = self._pending_buy_orders_by_market.get(market_tuple)
-                            if pending_buys is not None and order_id in pending_buys:
-                                pending_buys.discard(order_id)
-                                if len(pending_buys) == 0:
-                                    self._pending_buy_orders_by_market.pop(market_tuple, None)
-
-                            # Try removing from pending sell orders
-                            pending_sells = self._pending_sell_orders_by_market.get(market_tuple)
-                            if pending_sells is not None and order_id in pending_sells:
-                                pending_sells.discard(order_id)
-                                if len(pending_sells) == 0:
-                                    self._pending_sell_orders_by_market.pop(market_tuple, None)
-                        except Exception:
-                            pass
+                        self.c_remove_pending_order(market_tuple, order_id, "")
 
                         # Enforce cooldown for this market
                         self._last_failure_timestamps[market_tuple] = self._current_timestamp
@@ -1128,14 +1096,8 @@ cdef class ArbitrageLStrategy(StrategyBase):
         cdef object buy_price_decimal = Decimal(str(buy_price))
         cdef object sell_price_decimal = Decimal(str(sell_price))
         cdef object dec_safe_amount = Decimal(str(max(0.0, amount - QUANTIZATION_EPSILON)))
-        try:
-            quantized_buy = buy_market.c_quantize_order_amount(buy_market_tuple.trading_pair, dec_safe_amount, buy_price_decimal)
-        except Exception:
-            quantized_buy = buy_market.quantize_order_amount(buy_market_tuple.trading_pair, dec_safe_amount)
-        try:
-            quantized_sell = sell_market.c_quantize_order_amount(sell_market_tuple.trading_pair, dec_safe_amount, sell_price_decimal)
-        except Exception:
-            quantized_sell = sell_market.quantize_order_amount(sell_market_tuple.trading_pair, dec_safe_amount)
+        quantized_buy = self.c_safe_quantize_order_amount(buy_market, buy_market_tuple.trading_pair, dec_safe_amount, buy_price_decimal)
+        quantized_sell = self.c_safe_quantize_order_amount(sell_market, sell_market_tuple.trading_pair, dec_safe_amount, sell_price_decimal)
         quantized_amount = min(quantized_buy, quantized_sell)
         
         # Safety cap: re-check sell venue's live available base and re-quantize to prevent oversold at submission time
@@ -1143,15 +1105,7 @@ cdef class ArbitrageLStrategy(StrategyBase):
         # Only do extra work if available shrank below our planned amount
         if sell_available_now + 1e-15 < float(quantized_amount):
             sell_cap_dec = Decimal(str(max(0.0, sell_available_now - QUANTIZATION_EPSILON)))
-            try:
-                quantized_sell_cap = sell_market.c_quantize_order_amount(
-                    sell_market_tuple.trading_pair,
-                    sell_cap_dec,
-                    sell_price_decimal)
-            except Exception:
-                quantized_sell_cap = sell_market.quantize_order_amount(
-                    sell_market_tuple.trading_pair,
-                    sell_cap_dec)
+            quantized_sell_cap = self.c_safe_quantize_order_amount(sell_market, sell_market_tuple.trading_pair, sell_cap_dec, sell_price_decimal)
             # Re-quantize buy side to the capped amount using Decimal math (avoid float conversions)
             buy_req = quantized_sell_cap
             dec_eps = Decimal("1e-12")
@@ -1159,15 +1113,7 @@ cdef class ArbitrageLStrategy(StrategyBase):
                 buy_req = Decimal("0")
             else:
                 buy_req = buy_req - dec_eps if buy_req > dec_eps else Decimal("0")
-            try:
-                quantized_buy_cap = buy_market.c_quantize_order_amount(
-                    buy_market_tuple.trading_pair,
-                    buy_req,
-                    buy_price_decimal)
-            except Exception:
-                quantized_buy_cap = buy_market.quantize_order_amount(
-                    buy_market_tuple.trading_pair,
-                    buy_req)
+            quantized_buy_cap = self.c_safe_quantize_order_amount(buy_market, buy_market_tuple.trading_pair, buy_req, buy_price_decimal)
             quantized_amount = min(quantized_amount, quantized_sell_cap, quantized_buy_cap)
 
         # Symmetric safety cap on buy venue: ensure we do not exceed current quote availability
@@ -1179,26 +1125,10 @@ cdef class ArbitrageLStrategy(StrategyBase):
             if buy_price > 0.0:
                 affordable_base = max(0.0, buy_quote_available_now / buy_price)
             affordable_dec = Decimal(str(max(0.0, affordable_base - QUANTIZATION_EPSILON)))
-            try:
-                q_buy2 = buy_market.c_quantize_order_amount(
-                    buy_market_tuple.trading_pair,
-                    affordable_dec,
-                    buy_price_decimal)
-            except Exception:
-                q_buy2 = buy_market.quantize_order_amount(
-                    buy_market_tuple.trading_pair,
-                    affordable_dec)
+            q_buy2 = self.c_safe_quantize_order_amount(buy_market, buy_market_tuple.trading_pair, affordable_dec, buy_price_decimal)
             # Align sell side to the reduced buy size
             sell_req2 = q_buy2 if q_buy2 is not None else Decimal("0")
-            try:
-                q_sell2 = sell_market.c_quantize_order_amount(
-                    sell_market_tuple.trading_pair,
-                    sell_req2,
-                    sell_price_decimal)
-            except Exception:
-                q_sell2 = sell_market.quantize_order_amount(
-                    sell_market_tuple.trading_pair,
-                    sell_req2)
+            q_sell2 = self.c_safe_quantize_order_amount(sell_market, sell_market_tuple.trading_pair, sell_req2, sell_price_decimal)
             # Handle potential None from quantization
             if q_buy2 is not None and q_sell2 is not None:
                 quantized_amount = min(quantized_amount, q_buy2, q_sell2)
@@ -1650,27 +1580,13 @@ cdef class ArbitrageLStrategy(StrategyBase):
         cdef object order_type = OrderType.LIMIT
         cdef object quantized_amount
         cdef object dec_safe_amount2 = Decimal(str(max(0.0, best_amount - QUANTIZATION_EPSILON)))
-        try:
-            quantized_amount = market.c_quantize_order_amount(
-                buy_market_tuple.trading_pair,
-                dec_safe_amount2,
-                Decimal(str(buy_price)))
-        except Exception:
-            quantized_amount = market.quantize_order_amount(buy_market_tuple.trading_pair, dec_safe_amount2)
+        quantized_amount = self.c_safe_quantize_order_amount(market, buy_market_tuple.trading_pair, dec_safe_amount2, Decimal(str(buy_price)))
         # Ensure not exceeding available quote after quantization
         cdef double max_affordable = 0.0
         if buy_price > 0:
             max_affordable = quote_bal / buy_price
         if float(quantized_amount) > max_affordable:
-            try:
-                quantized_amount = market.c_quantize_order_amount(
-                    buy_market_tuple.trading_pair,
-                    Decimal(str(max(0.0, max_affordable - QUANTIZATION_EPSILON))),
-                    Decimal(str(buy_price)))
-            except Exception:
-                quantized_amount = market.quantize_order_amount(
-                    buy_market_tuple.trading_pair,
-                    Decimal(str(max(0.0, max_affordable - QUANTIZATION_EPSILON))))
+            quantized_amount = self.c_safe_quantize_order_amount(market, buy_market_tuple.trading_pair, Decimal(str(max(0.0, max_affordable - QUANTIZATION_EPSILON))), Decimal(str(buy_price)))
         if quantized_amount <= Decimal("0"):
             return False
 
@@ -1772,15 +1688,7 @@ cdef class ArbitrageLStrategy(StrategyBase):
         cdef double buy_cap_base = 0.0
         if approx_ask > 0.0 and spend_cap > 0.0:
             buy_cap_base = spend_cap / approx_ask
-            try:
-                q = buy_market_tuple.market.c_quantize_order_amount(
-                    buy_market_tuple.trading_pair,
-                    Decimal(str(max(0.0, buy_cap_base - QUANTIZATION_EPSILON))),
-                    Decimal(str(approx_ask)))
-            except Exception:
-                q = buy_market_tuple.market.quantize_order_amount(
-                    buy_market_tuple.trading_pair,
-                    Decimal(str(max(0.0, buy_cap_base - QUANTIZATION_EPSILON))))
+            q = self.c_safe_quantize_order_amount(buy_market_tuple.market, buy_market_tuple.trading_pair, Decimal(str(max(0.0, buy_cap_base - QUANTIZATION_EPSILON))), Decimal(str(approx_ask)))
             if q is not None:
                 buy_cap_base = float(q)
             else:
@@ -1863,21 +1771,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
             # Also remove from completed orders set
             self._completed_orders.erase(order_id_str)
 
-            # Best-effort cleanup: if this maps to a pending buy-in order id, drop its pending amount 
-            try:
-                oid = order_id_str.decode('utf-8')
-            except Exception:
-                oid = None
-            if oid is not None:
-                try:
-                    pend = self._pending_buyin_orders.pop(oid, None)
-                    if pend is not None:
-                        asset_key, amt = pend
-                        self._pending_buyin_by_asset[asset_key] = max(0.0, float(self._pending_buyin_by_asset.get(asset_key, 0.0)) - float(amt))
-                        if self._pending_buyin_by_asset.get(asset_key, 0.0) <= 1e-15:
-                            self._pending_buyin_by_asset.pop(asset_key, None)
-                except Exception:
-                    pass
+            # TODO: Buy-in cleanup to be moved to helper script
+            # Placeholder for buy-in pending order cleanup during old order cleanup
+            pass
         
         # Warn if too many tracked orders
         if self._order_timestamps.size() > self._max_tracked_orders:

--- a/hummingbot/strategy/arbitrage_l/buy_in_handler.pyx
+++ b/hummingbot/strategy/arbitrage_l/buy_in_handler.pyx
@@ -1,0 +1,431 @@
+# distutils: language=c++
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+
+"""
+Buy-in handler for ArbitrageL strategy.
+
+Manages buy-in logic to ensure sufficient base asset holdings before executing arbitrage trades.
+"""
+
+import logging
+from decimal import Decimal
+from libc.stdint cimport int64_t
+from libcpp.pair cimport pair
+from libcpp.set cimport set as cpp_set
+from cython.operator cimport dereference as deref
+
+from hummingbot.core.data_type.common import OrderType
+from hummingbot.core.data_type.OrderBookEntry cimport OrderBookEntry
+
+cdef double QUANTIZATION_EPSILON = 1e-12
+cdef double EPSILON = 1e-10
+
+
+cdef class ArbitrageBuyInHandler:
+    """
+    Handles buy-in logic for arbitrage strategy.
+
+    Buy-in ensures the strategy has sufficient base asset holdings (in quote value terms)
+    before executing arbitrage. It places limit buy orders when holdings fall below target.
+    """
+
+    def __init__(self,
+                 object strategy,
+                 bint enabled,
+                 double target_usd,
+                 double min_profitability):
+        """
+        Initialize buy-in handler.
+
+        Args:
+            strategy: Reference to ArbitrageLStrategy instance
+            enabled: Whether buy-in is enabled
+            target_usd: Target base asset value in quote currency
+            min_profitability: Minimum profitability threshold for buy-in trades
+        """
+        self.strategy = strategy
+        self._enabled = enabled
+        self._target_usd = target_usd
+        self._min_profitability = min_profitability
+        self._completed = False
+        self._pending_by_asset = {}  # asset -> base amount
+        self._pending_orders = {}    # order_id -> (asset, amount)
+
+    @property
+    def is_active(self):
+        """Returns True if buy-in is enabled and not completed."""
+        return self._enabled and not self._completed
+
+    @property
+    def is_enabled(self):
+        """Returns True if buy-in is enabled (regardless of completion)."""
+        return self._enabled
+
+    @property
+    def is_completed(self):
+        """Returns True if buy-in target has been reached."""
+        return self._completed
+
+    cdef void c_maybe_disable(self):
+        """Disable buy-in globally for this run once target is reached."""
+        if self._completed and self._enabled:
+            self._enabled = False
+            self.strategy.log_with_clock(
+                logging.INFO,
+                "Buy-in completed. Disabling buy-in for this session.")
+
+    cdef double c_get_pending_base(self, str asset):
+        """Return in-flight buy-in base amount for asset."""
+        try:
+            return <double> self._pending_by_asset.get(asset, 0.0)
+        except Exception:
+            return 0.0
+
+    cdef pair[double, double] c_compute_value_and_shortfall(self,
+                                                            double base_balance,
+                                                            double last_bid):
+        """Return (current_value_quote, shortfall)."""
+        cdef double current_value = base_balance * last_bid
+        cdef double shortfall = 0.0
+        if current_value < self._target_usd:
+            shortfall = self._target_usd - current_value
+        return pair[double, double](current_value, shortfall)
+
+    cdef double c_get_aggregated_base_balance(self, str asset):
+        """Aggregate base balance using the same source as status (assets_df/balance_map)."""
+        cdef:
+            double total = 0.0
+            list unique_tuples
+            object assets_df
+            dict balance_map
+            object t
+        try:
+            unique_tuples, assets_df, balance_map = self.strategy.c_build_unique_tuples_assets_and_balance_map()
+            for t in unique_tuples:
+                if t.base_asset == asset:
+                    total += float(balance_map.get((t.market.name, asset), 0.0))
+        except Exception:
+            return 0.0
+        return total
+
+    cdef double c_get_adjusted_base_balance(self, str asset):
+        """Aggregated base balance plus pending buy-in base."""
+        cdef double agg = self.c_get_aggregated_base_balance(asset)
+        cdef double pend = self.c_get_pending_base(asset)
+        return agg + pend
+
+    cdef bint c_try_mark_complete(self,
+                                  str pair,
+                                  double current_value_quote,
+                                  double shortfall):
+        """Mark buy-in as completed if at target or remaining < min notional."""
+        if current_value_quote >= self._target_usd:
+            self._completed = True
+            self.c_maybe_disable()
+            return True
+        if shortfall > 0 and shortfall < self.strategy._min_order_usd:
+            self._completed = True
+            self.strategy.log_with_clock(
+                logging.INFO,
+                f"Buy-in considered complete on {pair}: "
+                f"shortfall {shortfall:.6f} < min notional {self.strategy._min_order_usd:.6f}")
+            self.c_maybe_disable()
+            return True
+        return False
+
+    cdef void c_scan_and_mark_completion(self):
+        """Re-evaluate the base asset against target and disable buy-in when done."""
+        if not self._enabled or self._completed:
+            return
+
+        cdef:
+            str asset_key
+            double last_bid = 0.0
+            double base_bal
+            pair[double, double] val_short
+            double current_value_quote
+            double shortfall
+            list unique_tuples
+            object assets_df
+            dict balance_map
+
+        # Determine the single base asset from the first market pair
+        asset_key = self.strategy._market_pairs[0].first.base_asset
+
+        # Get a non-zero bid from any active tuple with this base asset
+        last_bid = self.strategy.c_get_reference_bid_for_asset(asset_key)
+
+        # Build balances from the same source as status for consistency
+        unique_tuples, assets_df, balance_map = self.strategy.c_build_unique_tuples_assets_and_balance_map()
+
+        # Sum base using the same map
+        base_bal = 0.0
+        for t in unique_tuples:
+            if t.base_asset == asset_key:
+                base_bal += float(balance_map.get((t.market.name, asset_key), 0.0))
+
+        # Include any in-flight buy-in base to avoid stale underestimation
+        base_bal += self.c_get_pending_base(asset_key)
+        val_short = self.c_compute_value_and_shortfall(base_bal, last_bid)
+        current_value_quote = val_short.first
+        shortfall = val_short.second
+
+        # Concise info log about startup buy-in state and decision
+        try:
+            decision = "disable" if (current_value_quote >= self._target_usd or
+                                    (shortfall > 0 and shortfall < self.strategy._min_order_usd)) else "keep"
+            self.strategy.log_with_clock(
+                logging.INFO,
+                f"Buy-in check: asset={asset_key} base={base_bal:.6f} bid={last_bid:.6f} "
+                f"value={current_value_quote:.6f} target={self._target_usd:.6f} -> {decision}")
+        except Exception:
+            pass
+
+        if self.c_try_mark_complete(asset_key, current_value_quote, shortfall):
+            pass
+        self.c_maybe_disable()
+
+    def handle_order_completion(self, str order_id, bint is_buy):
+        """Clean up pending buy-in tracking on order completion."""
+        if not is_buy:
+            return
+        try:
+            pend = self._pending_orders.pop(order_id, None)
+            if pend is not None:
+                asset_key, amt = pend
+                self._pending_by_asset[asset_key] = max(
+                    0.0,
+                    float(self._pending_by_asset.get(asset_key, 0.0)) - float(amt))
+                if self._pending_by_asset.get(asset_key, 0.0) <= 1e-15:
+                    self._pending_by_asset.pop(asset_key, None)
+        except Exception:
+            pass
+
+    def handle_order_cancellation(self, str order_id):
+        """Clean up pending buy-in tracking on order cancellation."""
+        try:
+            pend = self._pending_orders.pop(order_id, None)
+            if pend is not None:
+                asset_key, amt = pend
+                self._pending_by_asset[asset_key] = max(
+                    0.0,
+                    float(self._pending_by_asset.get(asset_key, 0.0)) - float(amt))
+                if self._pending_by_asset.get(asset_key, 0.0) <= 1e-15:
+                    self._pending_by_asset.pop(asset_key, None)
+        except Exception:
+            pass
+
+    def handle_order_timeout(self, str order_id):
+        """Clean up pending buy-in tracking on order timeout."""
+        try:
+            pend = self._pending_orders.pop(order_id, None)
+            if pend is not None:
+                asset_key, amt = pend
+                self._pending_by_asset[asset_key] = max(
+                    0.0,
+                    float(self._pending_by_asset.get(asset_key, 0.0)) - float(amt))
+                if self._pending_by_asset.get(asset_key, 0.0) <= 1e-15:
+                    self._pending_by_asset.pop(asset_key, None)
+        except Exception:
+            pass
+
+    def handle_old_order_cleanup(self, str order_id):
+        """Clean up pending buy-in tracking during old order cleanup."""
+        try:
+            pend = self._pending_orders.pop(order_id, None)
+            if pend is not None:
+                asset_key, amt = pend
+                self._pending_by_asset[asset_key] = max(
+                    0.0,
+                    float(self._pending_by_asset.get(asset_key, 0.0)) - float(amt))
+                if self._pending_by_asset.get(asset_key, 0.0) <= 1e-15:
+                    self._pending_by_asset.pop(asset_key, None)
+        except Exception:
+            pass
+
+    def get_status_lines(self, list unique_tuples, dict balance_map):
+        """Get buy-in status lines for format_status()."""
+        if not self._enabled:
+            return []
+
+        lines = []
+        try:
+            # Collect base assets from active market pairs
+            aset = set()
+            for mp in self.strategy._market_pairs:
+                aset.add(mp.first.base_asset)
+                aset.add(mp.second.base_asset)
+            base_assets = sorted(aset)
+        except Exception:
+            base_assets = []
+
+        agg_lines = []
+        any_pending = False
+        for a in base_assets:
+            # Get a reference bid from any active tuple with this base asset
+            bid = self.strategy.c_get_reference_bid_for_asset(a)
+            # Aggregate available base balance
+            total_base = 0.0
+            for t in unique_tuples:
+                if t.base_asset == a:
+                    total_base += float(balance_map.get((t.market.name, a), 0.0))
+            total_value = total_base * bid
+            # Status should reflect the permanent global flag, not current valuation
+            is_pending = (not self._completed)
+            if is_pending:
+                any_pending = True
+            agg_lines.append(
+                f"    {a}: base={total_base:.6f} value={total_value:.6f} "
+                f"({'pending' if is_pending else 'completed'})")
+
+        if any_pending and self._enabled:
+            lines.extend([
+                "",
+                f"  Buy-in: target={self._target_usd:.6f} min_prof={self._min_profitability * 100:.2f}%"
+            ])
+            lines.extend(agg_lines)
+
+        return lines
+
+    cdef bint c_handle_buy_in(self, object buy_market_tuple, object sell_market_tuple):
+        """
+        Execute buy-in trade if needed.
+        Returns True if a buy-in was placed; False otherwise.
+        """
+        # CRITICAL SAFEGUARD: Prevent double execution
+        if self.strategy._last_global_trade_timestamp == self.strategy._current_timestamp:
+            return False
+
+        # CRITICAL: Set timestamp IMMEDIATELY to prevent race condition
+        self.strategy._last_global_trade_timestamp = self.strategy._current_timestamp
+
+        if not self._enabled:
+            return False
+
+        cdef:
+            str pair_str = buy_market_tuple.trading_pair
+            object market = buy_market_tuple.market
+            double base_bal = 0.0
+            double quote_bal = float(market.c_get_available_balance(buy_market_tuple.quote_asset))
+            double best_amount
+            double best_prof
+            double sell_price
+            double buy_price
+            tuple res
+            str asset_key = buy_market_tuple.base_asset
+
+        if self._completed:
+            return False
+
+        # Evaluate progress vs target and early complete
+        cdef double last_bid = self.strategy.c_get_reference_bid_for_asset(asset_key)
+        base_bal = self.c_get_adjusted_base_balance(asset_key)
+        cdef pair[double, double] val_short = self.c_compute_value_and_shortfall(base_bal, last_bid)
+        cdef double current_value_quote = val_short.first
+        cdef double shortfall = val_short.second
+
+        if self.c_try_mark_complete(pair_str, current_value_quote, shortfall):
+            return False
+
+        # Require quote balance to spend
+        if quote_bal <= 0:
+            return False
+
+        # Delegate to strategy for orderbook scanning (avoid circular dependency)
+        res = self.strategy.c_find_best_buyin_amount(
+            buy_market_tuple,
+            sell_market_tuple,
+            quote_bal,
+            shortfall,
+            self._min_profitability
+        )
+        best_amount = <double>res[0]
+        best_prof = <double>res[1]
+        sell_price = <double>res[2]
+        buy_price = <double>res[3]
+
+        if best_amount <= 0 or best_prof < self._min_profitability:
+            return False
+
+        # Place buy order
+        cdef object order_type = OrderType.LIMIT
+        cdef object quantized_amount
+        cdef object dec_safe_amount = Decimal(str(max(0.0, best_amount - QUANTIZATION_EPSILON)))
+
+        quantized_amount = self.strategy.c_safe_quantize_order_amount(
+            market, buy_market_tuple.trading_pair, dec_safe_amount, Decimal(str(buy_price)))
+
+        # Ensure not exceeding available quote after quantization
+        cdef double max_affordable = 0.0
+        if buy_price > 0:
+            max_affordable = quote_bal / buy_price
+        if float(quantized_amount) > max_affordable:
+            quantized_amount = self.strategy.c_safe_quantize_order_amount(
+                market, buy_market_tuple.trading_pair,
+                Decimal(str(max(0.0, max_affordable - QUANTIZATION_EPSILON))),
+                Decimal(str(buy_price)))
+
+        if quantized_amount <= Decimal("0"):
+            return False
+
+        # Apply max_order_size cap from trading rules
+        try:
+            buy_trading_rule = market._trading_rules.get(buy_market_tuple.trading_pair)
+            if buy_trading_rule is not None and buy_trading_rule.max_order_size > Decimal("0"):
+                if quantized_amount > buy_trading_rule.max_order_size:
+                    quantized_amount = min(quantized_amount, buy_trading_rule.max_order_size)
+        except Exception:
+            pass
+
+        # Enforce minimum notional
+        cdef double volume_usd = float(quantized_amount) * buy_price
+        if volume_usd < self.strategy._min_order_usd:
+            if self.c_try_mark_complete(pair_str, current_value_quote, shortfall):
+                return False
+            return False
+
+        try:
+            buy_order_id = self.strategy.c_buy_with_specific_market(
+                buy_market_tuple,
+                quantized_amount,
+                order_type=order_type,
+                price=Decimal(str(buy_price)),
+                expiration_seconds=self.strategy._next_trade_delay)
+        except Exception as e:
+            # Set failure timestamp to enforce cooldown
+            self.strategy._last_failure_timestamps[buy_market_tuple] = self.strategy._current_timestamp
+            self.strategy.logger().warning(f"Error submitting buy-in order to {market.name}: {e}")
+            return False
+
+        # Track order timestamp
+        cdef string buy_id_str = self.strategy._to_cpp_str(buy_order_id)
+        self.strategy._order_timestamps[buy_id_str] = self.strategy._current_timestamp
+
+        # Track pending BUY order
+        try:
+            if buy_market_tuple not in self.strategy._pending_buy_orders_by_market:
+                self.strategy._pending_buy_orders_by_market[buy_market_tuple] = set()
+            self.strategy._pending_buy_orders_by_market[buy_market_tuple].add(buy_order_id)
+        except Exception as e:
+            self.strategy.logger().warning(f"Failed to track pending buy-in order by market: {e}")
+
+        # Track pending base
+        try:
+            self._pending_orders[buy_order_id] = (asset_key, float(quantized_amount))
+            self._pending_by_asset[asset_key] = (
+                float(self._pending_by_asset.get(asset_key, 0.0)) + float(quantized_amount))
+        except Exception as e:
+            self.strategy.logger().warning(f"Failed to track pending buy-in for order {buy_order_id}: {e}")
+
+        # Check if target reached after placing
+        last_bid = self.strategy.c_get_reference_bid_for_asset(asset_key)
+        base_bal = self.c_get_adjusted_base_balance(asset_key)
+        val_short = self.c_compute_value_and_shortfall(base_bal, last_bid)
+        current_value_quote = val_short.first
+        shortfall = val_short.second
+        if self.c_try_mark_complete(pair_str, current_value_quote, shortfall):
+            self.c_maybe_disable()
+
+        return True


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:



**Tests performed by the developer**:



**Tips for QA testing**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors ArbitrageL buy-in into a dedicated handler, adds safe quantization and pending-order cleanup helpers, and wires handler across status, ticks, and order lifecycle.
> 
> - **Core refactor**:
>   - Move all buy-in state/logic from `arbitrage.pyx` into new `buy_in_handler.pyx` (`ArbitrageBuyInHandler`).
>   - Replace old buy-in fields/methods in `arbitrage.pxd/.pyx` with a single `_buy_in_handler` and delegate calls (status, readiness checks, execution, and completion scans).
> - **API/Signature changes**:
>   - Update `c_find_best_buyin_amount(...)` to accept `min_profitability` param and propagate through handler.
> - **Helpers & cleanup**:
>   - Add `c_safe_quantize_order_amount(...)` to centralize quantization with fallback; use in arbitrage and buy-in paths.
>   - Add `c_remove_pending_order(...)` to unify pending-order cleanup; use on completion/cancellation/timeout.
> - **Lifecycle integration**:
>   - Wire buy-in handler into `format_status`, startup readiness checks, main `c_tick` buy-in attempts (including reversed direction), and old-order cleanup.
>   - Delegate buy-in tracking updates on order completion/cancel/timeout to handler.
> - **Conversion rates**:
>   - Minor adjustments to cached/oracle conversion usage and periodic logging remain; core arbitrage logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31d74f772b394ad3b946b6f05b9dc41d54880b4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->