### PR TITLE
Claude/review orchestrator arbitrage 01 xi67 cb bsa3fj152 a uotg76

### DIFF
--- a/hummingbot/strategy/arbitrage_l/arbitrage.pxd
+++ b/hummingbot/strategy/arbitrage_l/arbitrage.pxd
@@ -49,8 +49,8 @@ cdef class ArbitrageLStrategy(StrategyBase):
         double _cached_quote_rate
         double _last_rate_update
         
-        # Buy-in handler (None when disabled)
-        object _buy_in_handler
+        # Position balancer handler (None when disabled)
+        object _position_balancer
 
 
         # Order tracking - single unified map

--- a/hummingbot/strategy/arbitrage_l/arbitrage.pyx
+++ b/hummingbot/strategy/arbitrage_l/arbitrage.pyx
@@ -34,7 +34,7 @@ from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 from hummingbot.strategy.arbitrage_l.arbitrage_config_map import arbitrage_l_config_map
 from hummingbot.core.data_type.order_book cimport OrderBook
 from hummingbot.core.data_type.OrderBookEntry cimport OrderBookEntry
-from hummingbot.strategy.arbitrage_l.buy_in_handler cimport ArbitrageBuyInHandler
+from hummingbot.strategy.arbitrage_l.position_balancer_handler cimport PositionBalancerHandler
 
 # Constants - Now configurable via init_params
 cdef:
@@ -71,7 +71,7 @@ cdef class ArbitrageLStrategy(StrategyBase):
         # Initialize defaults so attributes exist even if init_params isn't called yet
         self._last_global_trade_timestamp = 0.0
         self._last_failure_timestamps = {}
-        self._buy_in_handler = None  # Will be initialized in init_params if enabled
+        self._position_balancer = None  # Will be initialized in init_params if enabled
         # Track whether a given order_id has received any fill events
         self._orders_with_fills = set()
         # Track when orders first received fills (for filled order timeout cleanup)
@@ -111,9 +111,16 @@ cdef class ArbitrageLStrategy(StrategyBase):
                     rate_cache_duration: float = DEFAULT_RATE_CACHE_DURATION,
                     order_warning_delay: float = DEFAULT_ORDER_WARNING_DELAY,
                     max_tracked_orders: int = DEFAULT_MAX_TRACKED_ORDERS,
+                    # Position balancer - buy-in configuration
                     buy_in_enabled: bool = True,
                     buy_in_target_usd: float = 100.0,
-                    buy_in_min_profitability: float = 0.005,
+                    buy_in_spread_pct: float = 0.1,
+                    # Position balancer - sell-off configuration
+                    sell_off_enabled: bool = False,
+                    sell_off_target_usd: float = 1000.0,
+                    sell_off_spread_pct: float = 0.1,
+                    # Position balancer - order management
+                    position_balancer_refresh_interval: float = 10.0,
                     orchestrated_mode: bool = False):
         """Initialize arbitrage strategy with configurable parameters"""
         
@@ -187,12 +194,19 @@ cdef class ArbitrageLStrategy(StrategyBase):
         except Exception:
             pass
 
-        # Buy-in handler (only create if enabled to avoid overhead)
-        if buy_in_enabled:
-            self._buy_in_handler = ArbitrageBuyInHandler(
-                self, buy_in_enabled, buy_in_target_usd, buy_in_min_profitability)
+        # Position balancer handler (create if either buy or sell enabled)
+        if buy_in_enabled or sell_off_enabled:
+            self._position_balancer = PositionBalancerHandler(
+                self,
+                buy_in_enabled,
+                buy_in_target_usd,
+                buy_in_spread_pct,
+                sell_off_enabled,
+                sell_off_target_usd,
+                sell_off_spread_pct,
+                position_balancer_refresh_interval)
         else:
-            self._buy_in_handler = None
+            self._position_balancer = None
 
         # Orchestration mode (for multi-strategy orchestrator optimization)
         self._orchestrated_mode = orchestrated_mode
@@ -462,9 +476,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
                 lines.append(
                     f"    best: buy-{best_pair.first.market.name} sell-{best_pair.second.market.name} -> {best_prof * 100:+.4f}%")
 
-            # Buy-in status (delegate to handler)
-            if self._buy_in_handler is not None:
-                lines.extend(self._buy_in_handler.get_status_lines(unique_tuples, balance_map))
+            # Position balancer status (delegate to handler)
+            if self._position_balancer is not None:
+                lines.extend(self._position_balancer.get_status_lines(unique_tuples, balance_map))
 
             # Pending orders
             if self.tracked_limit_orders or self.tracked_market_orders:
@@ -509,11 +523,11 @@ cdef class ArbitrageLStrategy(StrategyBase):
                 # Orchestrated mode: check connectivity but skip redundant logging/buy-in
                 if not self.c_check_markets_ready_orchestrated():
                     return
-                # Mark ready and do one-time buy-in check if not done yet
+                # Mark ready and do one-time position balancer check if not done yet
                 if not self._all_markets_ready:
                     self._all_markets_ready = True
-                    if self._buy_in_handler is not None:
-                        self._buy_in_handler.c_scan_and_mark_completion()
+                    if self._position_balancer is not None:
+                        self._position_balancer.c_scan_and_mark_completion()
 
             # Early check: skip orderbook scanning if global cooldown is active
             # This optimization avoids expensive orderbook iterations when we can't trade anyway
@@ -542,32 +556,30 @@ cdef class ArbitrageLStrategy(StrategyBase):
 
             # Execute only the globally best profitable opportunity
             if best_buy is not None and best_sell is not None and best_profitability >= self._min_profitability:
-                if self._buy_in_handler is not None and self._buy_in_handler.is_active:
-                    # Try buy-in first if not completed
-                    if self._buy_in_handler.c_handle_buy_in(best_buy, best_sell):
-                        # buy-in executed; skip regular arbitrage this tick
+                if self._position_balancer is not None and self._position_balancer.is_active:
+                    # Try position balancing first (buy-in or sell-off)
+                    if self._position_balancer.c_handle_position_balancing(best_buy, best_sell):
+                        # Position balancing executed; skip regular arbitrage this tick
                         pass
                     else:
                         self.c_execute_arbitrage(best_buy, best_sell)
                 else:
                     self.c_execute_arbitrage(best_buy, best_sell)
-            elif self._buy_in_handler is not None and self._buy_in_handler.is_active and best_buy is not None and best_sell is not None:
-                # Not enough edge for normal arbitrage. Still try buy-in using its own threshold,
-                # and also try the reversed pairing in case that direction offers cheaper buys.
+            elif self._position_balancer is not None and self._position_balancer.is_active and best_buy is not None and best_sell is not None:
+                # Not enough edge for normal arbitrage. Still try position balancing.
                 # Attempt with current best direction (respect pending/cool-off)
-                placed_buyin = False
+                placed = False
                 if self.c_ready_for_new_orders([best_buy, best_sell]) and self.c_books_ready_for_direction(best_buy, best_sell):
-                    placed_buyin = self._buy_in_handler.c_handle_buy_in(best_buy, best_sell) or False
+                    placed = self._position_balancer.c_handle_position_balancing(best_buy, best_sell) or False
                 # Also attempt reversed only if nothing was placed in current direction
-                if (not placed_buyin) and self._buy_in_handler.is_active:
+                if (not placed) and self._position_balancer.is_active:
                     if self.c_ready_for_new_orders([best_sell, best_buy]) and self.c_books_ready_for_direction(best_sell, best_buy):
-                        self._buy_in_handler.c_handle_buy_in(best_sell, best_buy)
-            elif self._buy_in_handler is not None and self._buy_in_handler.is_active and best_buy is None:
-                # No arbitrageable pair found (likely due to zero sell-side base). Proactively scan all ordered
-                # pairs to try buy-in on any asset/venue where shortfall and edge allow it.
+                        self._position_balancer.c_handle_position_balancing(best_sell, best_buy)
+            elif self._position_balancer is not None and self._position_balancer.is_active and best_buy is None:
+                # No arbitrageable pair found. Proactively scan all pairs for position balancing.
                 for market_pair in self._market_pairs:
                     if self.c_ready_for_new_orders([market_pair.first, market_pair.second]) and self.c_books_ready_for_direction(market_pair.first, market_pair.second):
-                        if self._buy_in_handler.c_handle_buy_in(market_pair.first, market_pair.second):
+                        if self._position_balancer.c_handle_position_balancing(market_pair.first, market_pair.second):
                             break
 
             # Check ALL pending orders for timeouts every tick
@@ -603,12 +615,12 @@ cdef class ArbitrageLStrategy(StrategyBase):
                     self.logger().info("Markets ready. Trading started.")
                     # Debounce status logs for a short window to let connectors settle
                     self._status_debounce_until = self._current_timestamp + 2.0
-                # Run one-time global buy-in completion check now that markets are ready (always log once)
-                if self._buy_in_handler is not None:
-                    self.log_with_clock(logging.INFO, "Buy-in config enabled at startup; performing completion check.")
-                    self._buy_in_handler.c_scan_and_mark_completion()
+                # Run one-time position balancer completion check now that markets are ready
+                if self._position_balancer is not None:
+                    self.log_with_clock(logging.INFO, "Position balancer enabled at startup; performing completion check.")
+                    self._position_balancer.c_scan_and_mark_completion()
                 else:
-                    self.log_with_clock(logging.INFO, "Buy-in config disabled at startup.")
+                    self.log_with_clock(logging.INFO, "Position balancer disabled at startup.")
         
         # Check network status
         for market in self._sb_markets:
@@ -724,9 +736,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
                     logging.DEBUG,
                     f"{order_type} order completed on {market_pair_tuple[0].name}: {order_id}")
 
-            # Cleanup buy-in tracking (delegated to handler)
-            if self._buy_in_handler is not None:
-                self._buy_in_handler.handle_order_completion(order_id, is_buy)
+            # Cleanup position balancer tracking (delegated to handler)
+            if self._position_balancer is not None:
+                self._position_balancer.handle_order_completion(order_id, is_buy)
 
         except Exception as e:
             self.logger().error(f"Error handling {order_type.lower()} order completion: {e}", exc_info=True)
@@ -797,9 +809,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
             pass
         self._sb_order_tracker.c_stop_tracking_limit_order(market_pair, order_id)
 
-        # Cleanup buy-in tracking (delegated to handler)
-        if self._buy_in_handler is not None:
-            self._buy_in_handler.handle_order_cancellation(order_id)
+        # Cleanup position balancer tracking (delegated to handler)
+        if self._position_balancer is not None:
+            self._position_balancer.handle_order_cancellation(order_id)
 
         # Remove from pending orders tracking - check both buy and sell dicts
         self.c_remove_pending_order(market_pair, order_id, "cancelled")
@@ -906,9 +918,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
                             pass
                         self._sb_order_tracker.c_stop_tracking_limit_order(market_tuple, order_id)
 
-                        # Cleanup buy-in tracking (delegated to handler)
-                        if self._buy_in_handler is not None:
-                            self._buy_in_handler.handle_order_timeout(order_id)
+                        # Cleanup position balancer tracking (delegated to handler)
+                        if self._position_balancer is not None:
+                            self._position_balancer.handle_order_timeout(order_id)
 
                         # Remove from pending orders tracking - check both buy and sell dicts
                         self.c_remove_pending_order(market_tuple, order_id, "")
@@ -985,9 +997,9 @@ cdef class ArbitrageLStrategy(StrategyBase):
                     # Stop tracking the order
                     self._sb_order_tracker.c_stop_tracking_limit_order(market_tuple, order_id)
 
-                    # Cleanup buy-in tracking
-                    if self._buy_in_handler is not None:
-                        self._buy_in_handler.handle_order_timeout(order_id)
+                    # Cleanup position balancer tracking
+                    if self._position_balancer is not None:
+                        self._position_balancer.handle_order_timeout(order_id)
 
                     # Remove from pending orders tracking
                     self.c_remove_pending_order(market_tuple, order_id, "filled_timeout")
@@ -1590,11 +1602,11 @@ cdef class ArbitrageLStrategy(StrategyBase):
             # Also remove from completed orders set
             self._completed_orders.erase(order_id_str)
 
-            # Cleanup buy-in tracking (delegated to handler)
+            # Cleanup position balancer tracking (delegated to handler)
             try:
                 oid = order_id_str.decode('utf-8')
-                if self._buy_in_handler is not None and oid is not None:
-                    self._buy_in_handler.handle_old_order_cleanup(oid)
+                if self._position_balancer is not None and oid is not None:
+                    self._position_balancer.handle_old_order_cleanup(oid)
             except Exception:
                 pass
         

--- a/hummingbot/strategy/arbitrage_l/arbitrage_config_map.py
+++ b/hummingbot/strategy/arbitrage_l/arbitrage_config_map.py
@@ -169,38 +169,83 @@ def _is_buy_in_enabled() -> bool:
     except Exception:
         return False
 
+
+def _is_sell_off_enabled() -> bool:
+    """Helper to decide whether sell-off specific fields should be prompted."""
+    try:
+        enabled = arbitrage_l_config_map.get("sell_off_enabled").value
+        return bool(enabled)
+    except Exception:
+        return False
+
 arbitrage_l_config_map = {
     "strategy": ConfigVar(
         key="strategy",
         prompt="",
         default="arbitrage_l"
     ),
-    # Optional buy-in module
+    # Position Balancer - Buy-in Configuration
     "buy_in_enabled": ConfigVar(
         key="buy_in_enabled",
         type_str="bool",
-        prompt="Enable initial buy-in if base asset holdings are below target? (Yes/No)",
+        prompt="Enable buy-in to acquire assets when below target? (Yes/No)",
         prompt_on_new=True,
         default=True,
         validator=lambda v: validate_bool(v),
     ),
     "buy_in_target_usdt": ConfigVar(
         key="buy_in_target_usdt",
-        prompt="Target base asset value to accumulate (in quote units, e.g., USDT) >>> ",
+        prompt="Target minimum base asset value (in quote units, e.g., USDT) >>> ",
         prompt_on_new=False,
         default=Decimal("100"),
         validator=lambda v: validate_decimal(v, Decimal(0), inclusive=False),
         type_str="decimal",
         required_if=_is_buy_in_enabled,
     ),
-    "buy_in_min_profitability": ConfigVar(
-        key="buy_in_min_profitability",
-        prompt="Minimum cross-market edge (%) required to trigger buy-in (e.g., 0.5) >>> ",
+    "buy_in_spread_pct": ConfigVar(
+        key="buy_in_spread_pct",
+        prompt="Spread percentage below top bid for buy limit orders (e.g., 0.1 for 0.1%) >>> ",
         prompt_on_new=False,
-        default=Decimal("0.5"),
-        validator=lambda v: validate_decimal(v, Decimal(-100), Decimal("100"), inclusive=True),
+        default=Decimal("0.1"),
+        validator=lambda v: validate_decimal(v, Decimal(0), Decimal("100"), inclusive=True),
         type_str="decimal",
         required_if=_is_buy_in_enabled,
+    ),
+    # Position Balancer - Sell-off Configuration
+    "sell_off_enabled": ConfigVar(
+        key="sell_off_enabled",
+        type_str="bool",
+        prompt="Enable sell-off to reduce assets when above target? (Yes/No)",
+        prompt_on_new=False,
+        default=False,
+        validator=lambda v: validate_bool(v),
+    ),
+    "sell_off_target_usd": ConfigVar(
+        key="sell_off_target_usd",
+        prompt="Target maximum base asset value (in quote units, e.g., USDT) >>> ",
+        prompt_on_new=False,
+        default=Decimal("1000"),
+        validator=lambda v: validate_decimal(v, Decimal(0), inclusive=False),
+        type_str="decimal",
+        required_if=_is_sell_off_enabled,
+    ),
+    "sell_off_spread_pct": ConfigVar(
+        key="sell_off_spread_pct",
+        prompt="Spread percentage above top ask for sell limit orders (e.g., 0.1 for 0.1%) >>> ",
+        prompt_on_new=False,
+        default=Decimal("0.1"),
+        validator=lambda v: validate_decimal(v, Decimal(0), Decimal("100"), inclusive=True),
+        type_str="decimal",
+        required_if=_is_sell_off_enabled,
+    ),
+    # Position Balancer - Order Management
+    "position_balancer_refresh_interval": ConfigVar(
+        key="position_balancer_refresh_interval",
+        prompt="How often to cancel and replace limit orders (seconds) >>> ",
+        prompt_on_new=False,
+        default=Decimal("10"),
+        validator=lambda v: validate_decimal(v, Decimal(1), inclusive=True),
+        type_str="decimal",
     ),
     "primary_market": ConfigVar(
         key="primary_market",

--- a/hummingbot/strategy/arbitrage_l/position_balancer_handler.pxd
+++ b/hummingbot/strategy/arbitrage_l/position_balancer_handler.pxd
@@ -1,0 +1,49 @@
+# distutils: language=c++
+from libcpp.pair cimport pair
+
+cdef class PositionBalancerHandler:
+    """
+    Universal position balancing handler for ArbitrageL strategy.
+    Supports both buying (when below target) and selling (when above target).
+    """
+    cdef:
+        object strategy
+        # Buy-in configuration
+        bint _buy_enabled
+        double _buy_target_usd
+        double _buy_spread_pct
+        # Sell-off configuration
+        bint _sell_enabled
+        double _sell_target_usd
+        double _sell_spread_pct
+        # Completion tracking
+        bint _buy_completed
+        bint _sell_completed
+        # Pending order tracking
+        dict _pending_buy_by_asset
+        dict _pending_sell_by_asset
+        dict _pending_buy_orders
+        dict _pending_sell_orders
+        # Limit order refresh
+        double _limit_refresh_interval
+        dict _last_buy_order_time
+        dict _last_sell_order_time
+        dict _active_buy_orders
+        dict _active_sell_orders
+
+    # Core methods
+    cdef void c_maybe_disable_buy(self)
+    cdef void c_maybe_disable_sell(self)
+    cdef double c_get_pending_buy_base(self, str asset)
+    cdef double c_get_pending_sell_base(self, str asset)
+    cdef pair[double, double] c_compute_value_and_buy_shortfall(self, double base_balance, double last_bid)
+    cdef pair[double, double] c_compute_value_and_sell_excess(self, double base_balance, double last_bid)
+    cdef double c_get_aggregated_base_balance(self, str asset)
+    cdef double c_get_adjusted_base_balance(self, str asset)
+    cdef bint c_try_mark_buy_complete(self, str pair, double current_value_quote, double shortfall)
+    cdef bint c_try_mark_sell_complete(self, str pair, double current_value_quote, double excess)
+    cdef void c_scan_and_mark_completion(self)
+    cdef bint c_handle_position_balancing(self, object buy_market_tuple, object sell_market_tuple)
+    cdef bint c_execute_buy_limit(self, object buy_market_tuple, object sell_market_tuple)
+    cdef bint c_execute_sell_limit(self, object buy_market_tuple, object sell_market_tuple)
+    cdef void c_cancel_stale_orders(self, str asset)

--- a/hummingbot/strategy/arbitrage_l/position_balancer_handler.pyx
+++ b/hummingbot/strategy/arbitrage_l/position_balancer_handler.pyx
@@ -1,0 +1,788 @@
+# distutils: language=c++
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+
+"""
+Position balancer handler for ArbitrageL strategy.
+
+Manages position balancing to maintain target asset holdings:
+- Buys when holdings fall below target (buy-in)
+- Sells when holdings exceed target (sell-off)
+- Uses limit orders with configurable spread from top bid/ask
+"""
+
+import logging
+from decimal import Decimal
+from libc.stdint cimport int64_t
+from libcpp.pair cimport pair
+from libcpp.string cimport string
+from libcpp.set cimport set as cpp_set
+from cython.operator cimport dereference as deref
+
+from hummingbot.core.data_type.common import OrderType
+from hummingbot.core.data_type.OrderBookEntry cimport OrderBookEntry
+from hummingbot.core.data_type.order_book cimport OrderBook
+
+cdef double QUANTIZATION_EPSILON = 1e-12
+cdef double EPSILON = 1e-10
+
+
+cdef class PositionBalancerHandler:
+    """
+    Handles position balancing logic for arbitrage strategy.
+
+    Position balancing ensures the strategy maintains target asset holdings:
+    - Buy-in: When asset value < buy_target_usd, place buy limit orders
+    - Sell-off: When asset value > sell_target_usd, place sell limit orders
+
+    Uses limit orders with configurable spread from top bid/ask (order_book_alignment pattern).
+    """
+
+    def __init__(self,
+                 object strategy,
+                 bint buy_enabled,
+                 double buy_target_usd,
+                 double buy_spread_pct,
+                 bint sell_enabled,
+                 double sell_target_usd,
+                 double sell_spread_pct,
+                 double limit_refresh_interval):
+        """
+        Initialize position balancer handler.
+
+        Args:
+            strategy: Reference to ArbitrageLStrategy instance
+            buy_enabled: Whether buy-in is enabled
+            buy_target_usd: Target minimum asset value in quote currency
+            buy_spread_pct: Spread percentage below top bid for buy orders (e.g., 0.1 = 0.1%)
+            sell_enabled: Whether sell-off is enabled
+            sell_target_usd: Target maximum asset value in quote currency
+            sell_spread_pct: Spread percentage above top ask for sell orders (e.g., 0.1 = 0.1%)
+            limit_refresh_interval: How often to cancel and replace limit orders (seconds)
+        """
+        self.strategy = strategy
+
+        # Buy-in configuration
+        self._buy_enabled = buy_enabled
+        self._buy_target_usd = buy_target_usd
+        self._buy_spread_pct = buy_spread_pct / 100.0  # Convert to decimal
+
+        # Sell-off configuration
+        self._sell_enabled = sell_enabled
+        self._sell_target_usd = sell_target_usd
+        self._sell_spread_pct = sell_spread_pct / 100.0  # Convert to decimal
+
+        # Completion tracking
+        self._buy_completed = False
+        self._sell_completed = False
+
+        # Pending order tracking (separate for buy/sell)
+        self._pending_buy_by_asset = {}   # asset -> base amount pending
+        self._pending_sell_by_asset = {}  # asset -> base amount pending
+        self._pending_buy_orders = {}     # order_id -> (asset, amount)
+        self._pending_sell_orders = {}    # order_id -> (asset, amount)
+
+        # Limit order refresh
+        self._limit_refresh_interval = limit_refresh_interval
+        self._last_buy_order_time = {}    # asset -> timestamp
+        self._last_sell_order_time = {}   # asset -> timestamp
+        self._active_buy_orders = {}      # asset -> order_id
+        self._active_sell_orders = {}     # asset -> order_id
+
+    @property
+    def is_buy_active(self):
+        """Returns True if buy-in is enabled and not completed."""
+        return self._buy_enabled and not self._buy_completed
+
+    @property
+    def is_sell_active(self):
+        """Returns True if sell-off is enabled and not completed."""
+        return self._sell_enabled and not self._sell_completed
+
+    @property
+    def is_active(self):
+        """Returns True if either buy or sell is active."""
+        return self.is_buy_active or self.is_sell_active
+
+    @property
+    def is_buy_enabled(self):
+        """Returns True if buy-in is enabled (regardless of completion)."""
+        return self._buy_enabled
+
+    @property
+    def is_sell_enabled(self):
+        """Returns True if sell-off is enabled (regardless of completion)."""
+        return self._sell_enabled
+
+    @property
+    def is_buy_completed(self):
+        """Returns True if buy-in target has been reached."""
+        return self._buy_completed
+
+    @property
+    def is_sell_completed(self):
+        """Returns True if sell-off target has been reached."""
+        return self._sell_completed
+
+    cdef void c_maybe_disable_buy(self):
+        """Disable buy-in globally once target is reached."""
+        if self._buy_completed and self._buy_enabled:
+            self._buy_enabled = False
+            self.strategy.log_with_clock(
+                logging.INFO,
+                "Buy-in target reached. Disabling buy-in for this session.")
+
+    cdef void c_maybe_disable_sell(self):
+        """Disable sell-off globally once target is reached."""
+        if self._sell_completed and self._sell_enabled:
+            self._sell_enabled = False
+            self.strategy.log_with_clock(
+                logging.INFO,
+                "Sell-off target reached. Disabling sell-off for this session.")
+
+    cdef double c_get_pending_buy_base(self, str asset):
+        """Return in-flight buy order base amount for asset."""
+        try:
+            return <double> self._pending_buy_by_asset.get(asset, 0.0)
+        except Exception:
+            return 0.0
+
+    cdef double c_get_pending_sell_base(self, str asset):
+        """Return in-flight sell order base amount for asset."""
+        try:
+            return <double> self._pending_sell_by_asset.get(asset, 0.0)
+        except Exception:
+            return 0.0
+
+    cdef pair[double, double] c_compute_value_and_buy_shortfall(self,
+                                                                 double base_balance,
+                                                                 double last_bid):
+        """
+        Compute current value and buy shortfall.
+        Returns (current_value_quote, shortfall).
+        Shortfall is positive if we need to buy more.
+        """
+        cdef double current_value = base_balance * last_bid
+        cdef double shortfall = 0.0
+        if current_value < self._buy_target_usd:
+            shortfall = self._buy_target_usd - current_value
+        return pair[double, double](current_value, shortfall)
+
+    cdef pair[double, double] c_compute_value_and_sell_excess(self,
+                                                               double base_balance,
+                                                               double last_bid):
+        """
+        Compute current value and sell excess.
+        Returns (current_value_quote, excess).
+        Excess is positive if we need to sell some.
+        """
+        cdef double current_value = base_balance * last_bid
+        cdef double excess = 0.0
+        if current_value > self._sell_target_usd:
+            excess = current_value - self._sell_target_usd
+        return pair[double, double](current_value, excess)
+
+    cdef double c_get_aggregated_base_balance(self, str asset):
+        """Aggregate base balance using the same source as status (balance_map)."""
+        cdef:
+            double total = 0.0
+            list unique_tuples
+            object assets_df
+            dict balance_map
+            object t
+        try:
+            unique_tuples, assets_df, balance_map = self.strategy.c_build_unique_tuples_assets_and_balance_map()
+            for t in unique_tuples:
+                if t.base_asset == asset:
+                    total += float(balance_map.get((t.market.name, asset), 0.0))
+        except Exception:
+            return 0.0
+        return total
+
+    cdef double c_get_adjusted_base_balance(self, str asset):
+        """
+        Get adjusted base balance accounting for pending orders.
+        For buy target checking: add pending buys
+        For sell target checking: subtract pending sells
+        """
+        cdef double agg = self.c_get_aggregated_base_balance(asset)
+        cdef double pending_buy = self.c_get_pending_buy_base(asset)
+        cdef double pending_sell = self.c_get_pending_sell_base(asset)
+        # Net balance = actual + pending buys - pending sells
+        return agg + pending_buy - pending_sell
+
+    cdef bint c_try_mark_buy_complete(self,
+                                      str pair,
+                                      double current_value_quote,
+                                      double shortfall):
+        """Mark buy-in as completed if at target or remaining < min notional."""
+        if current_value_quote >= self._buy_target_usd:
+            self._buy_completed = True
+            self.c_maybe_disable_buy()
+            return True
+        if shortfall > 0 and shortfall < self.strategy._min_order_usd:
+            self._buy_completed = True
+            self.strategy.log_with_clock(
+                logging.INFO,
+                f"Buy-in considered complete on {pair}: "
+                f"shortfall {shortfall:.6f} < min notional {self.strategy._min_order_usd:.6f}")
+            self.c_maybe_disable_buy()
+            return True
+        return False
+
+    cdef bint c_try_mark_sell_complete(self,
+                                       str pair,
+                                       double current_value_quote,
+                                       double excess):
+        """Mark sell-off as completed if at target or remaining < min notional."""
+        if current_value_quote <= self._sell_target_usd:
+            self._sell_completed = True
+            self.c_maybe_disable_sell()
+            return True
+        if excess > 0 and excess < self.strategy._min_order_usd:
+            self._sell_completed = True
+            self.strategy.log_with_clock(
+                logging.INFO,
+                f"Sell-off considered complete on {pair}: "
+                f"excess {excess:.6f} < min notional {self.strategy._min_order_usd:.6f}")
+            self.c_maybe_disable_sell()
+            return True
+        return False
+
+    cdef void c_scan_and_mark_completion(self):
+        """Re-evaluate asset balance and complete buy/sell if targets reached."""
+        cdef:
+            str asset_key
+            double last_bid = 0.0
+            double base_bal
+            pair[double, double] val_short
+            pair[double, double] val_excess
+            double current_value_quote
+            double shortfall
+            double excess
+            list unique_tuples
+            object assets_df
+            dict balance_map
+
+        # Skip if both disabled
+        if not self._buy_enabled and not self._sell_enabled:
+            return
+
+        # Determine the base asset from the first market pair
+        asset_key = self.strategy._market_pairs[0].first.base_asset
+
+        # Get reference bid
+        last_bid = self.strategy.c_get_reference_bid_for_asset(asset_key)
+
+        # Build balances
+        unique_tuples, assets_df, balance_map = self.strategy.c_build_unique_tuples_assets_and_balance_map()
+
+        # Sum base balance
+        base_bal = 0.0
+        for t in unique_tuples:
+            if t.base_asset == asset_key:
+                base_bal += float(balance_map.get((t.market.name, asset_key), 0.0))
+
+        # Include pending orders
+        base_bal += self.c_get_pending_buy_base(asset_key)
+        base_bal -= self.c_get_pending_sell_base(asset_key)
+
+        # Check buy completion
+        if self._buy_enabled and not self._buy_completed:
+            val_short = self.c_compute_value_and_buy_shortfall(base_bal, last_bid)
+            current_value_quote = val_short.first
+            shortfall = val_short.second
+
+            try:
+                decision = "complete" if (current_value_quote >= self._buy_target_usd or
+                                         (shortfall > 0 and shortfall < self.strategy._min_order_usd)) else "active"
+                self.strategy.log_with_clock(
+                    logging.INFO,
+                    f"Buy-in check: asset={asset_key} base={base_bal:.6f} bid={last_bid:.6f} "
+                    f"value={current_value_quote:.6f} target={self._buy_target_usd:.6f} -> {decision}")
+            except Exception:
+                pass
+
+            self.c_try_mark_buy_complete(asset_key, current_value_quote, shortfall)
+
+        # Check sell completion
+        if self._sell_enabled and not self._sell_completed:
+            val_excess = self.c_compute_value_and_sell_excess(base_bal, last_bid)
+            current_value_quote = val_excess.first
+            excess = val_excess.second
+
+            try:
+                decision = "complete" if (current_value_quote <= self._sell_target_usd or
+                                         (excess > 0 and excess < self.strategy._min_order_usd)) else "active"
+                self.strategy.log_with_clock(
+                    logging.INFO,
+                    f"Sell-off check: asset={asset_key} base={base_bal:.6f} bid={last_bid:.6f} "
+                    f"value={current_value_quote:.6f} target={self._sell_target_usd:.6f} -> {decision}")
+            except Exception:
+                pass
+
+            self.c_try_mark_sell_complete(asset_key, current_value_quote, excess)
+
+        self.c_maybe_disable_buy()
+        self.c_maybe_disable_sell()
+
+    def handle_order_completion(self, str order_id, bint is_buy):
+        """Clean up pending order tracking on order completion."""
+        try:
+            if is_buy:
+                pend = self._pending_buy_orders.pop(order_id, None)
+                if pend is not None:
+                    asset_key, amt = pend
+                    self._pending_buy_by_asset[asset_key] = max(
+                        0.0,
+                        float(self._pending_buy_by_asset.get(asset_key, 0.0)) - float(amt))
+                    if self._pending_buy_by_asset.get(asset_key, 0.0) <= 1e-15:
+                        self._pending_buy_by_asset.pop(asset_key, None)
+                    # Remove from active tracking
+                    if self._active_buy_orders.get(asset_key) == order_id:
+                        self._active_buy_orders.pop(asset_key, None)
+            else:
+                pend = self._pending_sell_orders.pop(order_id, None)
+                if pend is not None:
+                    asset_key, amt = pend
+                    self._pending_sell_by_asset[asset_key] = max(
+                        0.0,
+                        float(self._pending_sell_by_asset.get(asset_key, 0.0)) - float(amt))
+                    if self._pending_sell_by_asset.get(asset_key, 0.0) <= 1e-15:
+                        self._pending_sell_by_asset.pop(asset_key, None)
+                    # Remove from active tracking
+                    if self._active_sell_orders.get(asset_key) == order_id:
+                        self._active_sell_orders.pop(asset_key, None)
+        except Exception:
+            pass
+
+    def handle_order_cancellation(self, str order_id):
+        """Clean up pending order tracking on order cancellation."""
+        # Try both buy and sell
+        self.handle_order_completion(order_id, True)
+        self.handle_order_completion(order_id, False)
+
+    def handle_order_timeout(self, str order_id):
+        """Clean up pending order tracking on order timeout."""
+        self.handle_order_completion(order_id, True)
+        self.handle_order_completion(order_id, False)
+
+    def handle_old_order_cleanup(self, str order_id):
+        """Clean up pending order tracking during old order cleanup."""
+        self.handle_order_completion(order_id, True)
+        self.handle_order_completion(order_id, False)
+
+    def get_status_lines(self, list unique_tuples, dict balance_map):
+        """Get position balancer status lines for format_status()."""
+        if not self._buy_enabled and not self._sell_enabled:
+            return []
+
+        lines = []
+        try:
+            # Collect base assets from active market pairs
+            aset = set()
+            for mp in self.strategy._market_pairs:
+                aset.add(mp.first.base_asset)
+                aset.add(mp.second.base_asset)
+            base_assets = sorted(aset)
+        except Exception:
+            base_assets = []
+
+        agg_lines = []
+        any_active = False
+        for a in base_assets:
+            # Get reference bid
+            bid = self.strategy.c_get_reference_bid_for_asset(a)
+            # Aggregate base balance
+            total_base = 0.0
+            for t in unique_tuples:
+                if t.base_asset == a:
+                    total_base += float(balance_map.get((t.market.name, a), 0.0))
+            total_value = total_base * bid
+
+            # Status flags
+            buy_status = "active" if (self._buy_enabled and not self._buy_completed) else "completed"
+            sell_status = "active" if (self._sell_enabled and not self._sell_completed) else "completed"
+
+            if buy_status == "active" or sell_status == "active":
+                any_active = True
+
+            status_str = f"buy:{buy_status}"
+            if self._sell_enabled:
+                status_str += f" sell:{sell_status}"
+
+            agg_lines.append(
+                f"    {a}: base={total_base:.6f} value={total_value:.6f} ({status_str})")
+
+        if any_active:
+            header = "  Position Balancer:"
+            if self._buy_enabled and not self._buy_completed:
+                header += f" buy_target={self._buy_target_usd:.6f}"
+            if self._sell_enabled and not self._sell_completed:
+                header += f" sell_target={self._sell_target_usd:.6f}"
+
+            lines.extend([
+                "",
+                header
+            ])
+            lines.extend(agg_lines)
+
+        return lines
+
+    cdef void c_cancel_stale_orders(self, str asset):
+        """Cancel stale buy/sell limit orders for refresh."""
+        cdef double current_time = self.strategy._current_timestamp
+
+        # Check buy orders
+        if asset in self._active_buy_orders:
+            last_time = self._last_buy_order_time.get(asset, 0.0)
+            if current_time - last_time > self._limit_refresh_interval:
+                order_id = self._active_buy_orders.get(asset)
+                if order_id:
+                    try:
+                        # Find market tuple for this order
+                        for mp in self.strategy._market_pairs:
+                            if mp.first.base_asset == asset:
+                                self.strategy.c_cancel_order(mp.first, order_id)
+                                self.strategy.logger().info(
+                                    f"Cancelled stale buy order {order_id} for {asset} (refresh)")
+                                break
+                    except Exception as e:
+                        self.strategy.logger().warning(f"Failed to cancel stale buy order: {e}")
+
+        # Check sell orders
+        if asset in self._active_sell_orders:
+            last_time = self._last_sell_order_time.get(asset, 0.0)
+            if current_time - last_time > self._limit_refresh_interval:
+                order_id = self._active_sell_orders.get(asset)
+                if order_id:
+                    try:
+                        # Find market tuple for this order
+                        for mp in self.strategy._market_pairs:
+                            if mp.first.base_asset == asset:
+                                self.strategy.c_cancel_order(mp.first, order_id)
+                                self.strategy.logger().info(
+                                    f"Cancelled stale sell order {order_id} for {asset} (refresh)")
+                                break
+                    except Exception as e:
+                        self.strategy.logger().warning(f"Failed to cancel stale sell order: {e}")
+
+    cdef bint c_handle_position_balancing(self, object buy_market_tuple, object sell_market_tuple):
+        """
+        Main entry point for position balancing.
+        Decides whether to buy or sell based on current position.
+        Returns True if an order was placed.
+        """
+        # CRITICAL SAFEGUARD: Prevent double execution
+        if self.strategy._last_global_trade_timestamp == self.strategy._current_timestamp:
+            return False
+
+        if not self._buy_enabled and not self._sell_enabled:
+            return False
+
+        cdef:
+            str asset_key = buy_market_tuple.base_asset
+            double last_bid = self.strategy.c_get_reference_bid_for_asset(asset_key)
+            double base_bal = self.c_get_adjusted_base_balance(asset_key)
+            pair[double, double] val_result
+            double current_value
+            double shortfall_or_excess
+            bint placed = False
+
+        # Cancel stale orders for refresh
+        self.c_cancel_stale_orders(asset_key)
+
+        # Check if we need to buy
+        if self._buy_enabled and not self._buy_completed:
+            val_result = self.c_compute_value_and_buy_shortfall(base_bal, last_bid)
+            current_value = val_result.first
+            shortfall_or_excess = val_result.second
+
+            if shortfall_or_excess > 0:
+                # Check if already have pending buy order
+                if asset_key not in self._active_buy_orders:
+                    if not self.c_try_mark_buy_complete(asset_key, current_value, shortfall_or_excess):
+                        placed = self.c_execute_buy_limit(buy_market_tuple, sell_market_tuple)
+                        if placed:
+                            return True
+
+        # Check if we need to sell
+        if self._sell_enabled and not self._sell_completed:
+            val_result = self.c_compute_value_and_sell_excess(base_bal, last_bid)
+            current_value = val_result.first
+            shortfall_or_excess = val_result.second
+
+            if shortfall_or_excess > 0:
+                # Check if already have pending sell order
+                if asset_key not in self._active_sell_orders:
+                    if not self.c_try_mark_sell_complete(asset_key, current_value, shortfall_or_excess):
+                        placed = self.c_execute_sell_limit(buy_market_tuple, sell_market_tuple)
+                        if placed:
+                            return True
+
+        return False
+
+    cdef bint c_execute_buy_limit(self, object buy_market_tuple, object sell_market_tuple):
+        """
+        Execute buy using limit order with spread from top bid.
+        Pattern: Place limit buy at (top_bid * (1 - spread_pct))
+        """
+        # CRITICAL: Set timestamp IMMEDIATELY to prevent race condition
+        self.strategy._last_global_trade_timestamp = self.strategy._current_timestamp
+
+        cdef:
+            str asset_key = buy_market_tuple.base_asset
+            object market = buy_market_tuple.market
+            double quote_bal = float(market.c_get_available_balance(buy_market_tuple.quote_asset))
+            double base_bal = self.c_get_adjusted_base_balance(asset_key)
+            double last_bid = self.strategy.c_get_reference_bid_for_asset(asset_key)
+            pair[double, double] val_short = self.c_compute_value_and_buy_shortfall(base_bal, last_bid)
+            double current_value_quote = val_short.first
+            double shortfall = val_short.second
+
+        # Check if still needed
+        if self.c_try_mark_buy_complete(asset_key, current_value_quote, shortfall):
+            return False
+
+        if quote_bal <= 0:
+            return False
+
+        # Get top bid price via C-level orderbook
+        cdef:
+            OrderBook ob = market.c_get_order_book(buy_market_tuple.trading_pair)
+            cpp_set[OrderBookEntry].reverse_iterator bid_it
+            double top_bid
+            double buy_price
+            double max_affordable_base
+            double amount_to_buy
+            object quantized_amount
+            object order_type = OrderType.LIMIT
+            double volume_usd
+            str buy_order_id
+            string buy_id_str
+
+        if ob._bid_book.size() == 0:
+            return False
+
+        bid_it = ob._bid_book.rbegin()
+        top_bid = deref(bid_it).getPrice()
+
+        if top_bid <= 0:
+            return False
+
+        # Calculate limit price: top_bid * (1 - spread_pct)
+        buy_price = top_bid * (1.0 - self._buy_spread_pct)
+
+        # Calculate amount based on shortfall and available quote
+        max_affordable_base = quote_bal / buy_price if buy_price > 0 else 0.0
+        amount_to_buy = min(shortfall / last_bid if last_bid > 0 else 0.0, max_affordable_base)
+
+        if amount_to_buy <= EPSILON:
+            return False
+
+        # Quantize
+        quantized_amount = self.strategy.c_safe_quantize_order_amount(
+            market, buy_market_tuple.trading_pair,
+            Decimal(str(max(0.0, amount_to_buy - QUANTIZATION_EPSILON))),
+            Decimal(str(buy_price)))
+
+        if quantized_amount <= Decimal("0"):
+            return False
+
+        # Apply max_order_size cap
+        try:
+            trading_rule = market._trading_rules.get(buy_market_tuple.trading_pair)
+            if trading_rule is not None and trading_rule.max_order_size > Decimal("0"):
+                if quantized_amount > trading_rule.max_order_size:
+                    quantized_amount = trading_rule.max_order_size
+        except Exception:
+            pass
+
+        # Check minimum notional
+        volume_usd = float(quantized_amount) * buy_price
+        if volume_usd < self.strategy._min_order_usd:
+            # Too small, mark complete
+            if self.c_try_mark_buy_complete(asset_key, current_value_quote, shortfall):
+                return False
+            return False
+
+        # Place limit buy order
+        try:
+            buy_order_id = self.strategy.c_buy_with_specific_market(
+                buy_market_tuple,
+                quantized_amount,
+                order_type=order_type,
+                price=Decimal(str(buy_price)),
+                expiration_seconds=self.strategy._next_trade_delay)
+        except Exception as e:
+            self.strategy._last_failure_timestamps[buy_market_tuple] = self.strategy._current_timestamp
+            self.strategy.logger().warning(f"Error submitting buy limit order to {market.name}: {e}")
+            return False
+
+        # Track order
+        buy_id_str = self.strategy._to_cpp_str(buy_order_id)
+        self.strategy._order_timestamps[buy_id_str] = self.strategy._current_timestamp
+
+        # Track pending BUY order in strategy
+        try:
+            if buy_market_tuple not in self.strategy._pending_buy_orders_by_market:
+                self.strategy._pending_buy_orders_by_market[buy_market_tuple] = set()
+            self.strategy._pending_buy_orders_by_market[buy_market_tuple].add(buy_order_id)
+        except Exception as e:
+            self.strategy.logger().warning(f"Failed to track pending buy order by market: {e}")
+
+        # Track in balancer
+        try:
+            self._pending_buy_orders[buy_order_id] = (asset_key, float(quantized_amount))
+            self._pending_buy_by_asset[asset_key] = (
+                float(self._pending_buy_by_asset.get(asset_key, 0.0)) + float(quantized_amount))
+            self._active_buy_orders[asset_key] = buy_order_id
+            self._last_buy_order_time[asset_key] = self.strategy._current_timestamp
+        except Exception as e:
+            self.strategy.logger().warning(f"Failed to track buy limit order {buy_order_id}: {e}")
+
+        self.strategy.logger().info(
+            f"Placed buy limit order {buy_order_id} for {float(quantized_amount):.6f} {asset_key} "
+            f"at {buy_price:.8f} (spread: {self._buy_spread_pct * 100:.2f}%)")
+
+        # Check if target reached
+        base_bal = self.c_get_adjusted_base_balance(asset_key)
+        val_short = self.c_compute_value_and_buy_shortfall(base_bal, last_bid)
+        current_value_quote = val_short.first
+        shortfall = val_short.second
+        if self.c_try_mark_buy_complete(asset_key, current_value_quote, shortfall):
+            self.c_maybe_disable_buy()
+
+        return True
+
+    cdef bint c_execute_sell_limit(self, object buy_market_tuple, object sell_market_tuple):
+        """
+        Execute sell using limit order with spread from top ask.
+        Pattern: Place limit sell at (top_ask * (1 + spread_pct))
+        """
+        # CRITICAL: Set timestamp IMMEDIATELY to prevent race condition
+        self.strategy._last_global_trade_timestamp = self.strategy._current_timestamp
+
+        cdef:
+            str asset_key = sell_market_tuple.base_asset
+            object market = sell_market_tuple.market
+            double base_bal_raw = float(market.c_get_available_balance(sell_market_tuple.base_asset))
+            double base_bal = self.c_get_adjusted_base_balance(asset_key)
+            double last_bid = self.strategy.c_get_reference_bid_for_asset(asset_key)
+            pair[double, double] val_excess = self.c_compute_value_and_sell_excess(base_bal, last_bid)
+            double current_value_quote = val_excess.first
+            double excess = val_excess.second
+
+        # Check if still needed
+        if self.c_try_mark_sell_complete(asset_key, current_value_quote, excess):
+            return False
+
+        if base_bal_raw <= 0:
+            return False
+
+        # Get top ask price via C-level orderbook
+        cdef:
+            OrderBook ob = market.c_get_order_book(sell_market_tuple.trading_pair)
+            cpp_set[OrderBookEntry].iterator ask_it
+            double top_ask
+            double sell_price
+            double amount_to_sell
+            object quantized_amount
+            object order_type = OrderType.LIMIT
+            double volume_usd
+            str sell_order_id
+            string sell_id_str
+
+        if ob._ask_book.size() == 0:
+            return False
+
+        ask_it = ob._ask_book.begin()
+        top_ask = deref(ask_it).getPrice()
+
+        if top_ask <= 0:
+            return False
+
+        # Calculate limit price: top_ask * (1 + spread_pct)
+        sell_price = top_ask * (1.0 + self._sell_spread_pct)
+
+        # Calculate amount based on excess and available base
+        amount_to_sell = min(excess / last_bid if last_bid > 0 else 0.0, base_bal_raw)
+
+        if amount_to_sell <= EPSILON:
+            return False
+
+        # Quantize
+        quantized_amount = self.strategy.c_safe_quantize_order_amount(
+            market, sell_market_tuple.trading_pair,
+            Decimal(str(max(0.0, amount_to_sell - QUANTIZATION_EPSILON))),
+            Decimal(str(sell_price)))
+
+        if quantized_amount <= Decimal("0"):
+            return False
+
+        # Apply max_order_size cap
+        try:
+            trading_rule = market._trading_rules.get(sell_market_tuple.trading_pair)
+            if trading_rule is not None and trading_rule.max_order_size > Decimal("0"):
+                if quantized_amount > trading_rule.max_order_size:
+                    quantized_amount = trading_rule.max_order_size
+        except Exception:
+            pass
+
+        # Check minimum notional
+        volume_usd = float(quantized_amount) * sell_price
+        if volume_usd < self.strategy._min_order_usd:
+            # Too small, mark complete
+            if self.c_try_mark_sell_complete(asset_key, current_value_quote, excess):
+                return False
+            return False
+
+        # Place limit sell order
+        try:
+            sell_order_id = self.strategy.c_sell_with_specific_market(
+                sell_market_tuple,
+                quantized_amount,
+                order_type=order_type,
+                price=Decimal(str(sell_price)),
+                expiration_seconds=self.strategy._next_trade_delay)
+        except Exception as e:
+            self.strategy._last_failure_timestamps[sell_market_tuple] = self.strategy._current_timestamp
+            self.strategy.logger().warning(f"Error submitting sell limit order to {market.name}: {e}")
+            return False
+
+        # Track order
+        sell_id_str = self.strategy._to_cpp_str(sell_order_id)
+        self.strategy._order_timestamps[sell_id_str] = self.strategy._current_timestamp
+
+        # Track pending SELL order in strategy
+        try:
+            if sell_market_tuple not in self.strategy._pending_sell_orders_by_market:
+                self.strategy._pending_sell_orders_by_market[sell_market_tuple] = set()
+            self.strategy._pending_sell_orders_by_market[sell_market_tuple].add(sell_order_id)
+        except Exception as e:
+            self.strategy.logger().warning(f"Failed to track pending sell order by market: {e}")
+
+        # Track in balancer
+        try:
+            self._pending_sell_orders[sell_order_id] = (asset_key, float(quantized_amount))
+            self._pending_sell_by_asset[asset_key] = (
+                float(self._pending_sell_by_asset.get(asset_key, 0.0)) + float(quantized_amount))
+            self._active_sell_orders[asset_key] = sell_order_id
+            self._last_sell_order_time[asset_key] = self.strategy._current_timestamp
+        except Exception as e:
+            self.strategy.logger().warning(f"Failed to track sell limit order {sell_order_id}: {e}")
+
+        self.strategy.logger().info(
+            f"Placed sell limit order {sell_order_id} for {float(quantized_amount):.6f} {asset_key} "
+            f"at {sell_price:.8f} (spread: {self._sell_spread_pct * 100:.2f}%)")
+
+        # Check if target reached
+        base_bal = self.c_get_adjusted_base_balance(asset_key)
+        val_excess = self.c_compute_value_and_sell_excess(base_bal, last_bid)
+        current_value_quote = val_excess.first
+        excess = val_excess.second
+        if self.c_try_mark_sell_complete(asset_key, current_value_quote, excess):
+            self.c_maybe_disable_sell()
+
+        return True

--- a/hummingbot/strategy/arbitrage_l/start.py
+++ b/hummingbot/strategy/arbitrage_l/start.py
@@ -45,17 +45,32 @@ async def start(self):
         use_oracle_conversion_rate = arbitrage_l_config_map.get("use_oracle_conversion_rate").value
         secondary_to_primary_base_conversion_rate = arbitrage_l_config_map["secondary_to_primary_base_conversion_rate"].value
         secondary_to_primary_quote_conversion_rate = arbitrage_l_config_map["secondary_to_primary_quote_conversion_rate"].value
+        # Position balancer - buy-in configuration
         buy_in_enabled = arbitrage_l_config_map.get("buy_in_enabled").value
         buy_in_target_usdt = arbitrage_l_config_map.get("buy_in_target_usdt").value
-        buy_in_min_profitability_val = arbitrage_l_config_map.get("buy_in_min_profitability").value
-        # Fallbacks when importing older/partial configs
+        buy_in_spread_pct = arbitrage_l_config_map.get("buy_in_spread_pct").value
+        # Position balancer - sell-off configuration
+        sell_off_enabled = arbitrage_l_config_map.get("sell_off_enabled").value
+        sell_off_target_usd = arbitrage_l_config_map.get("sell_off_target_usd").value
+        sell_off_spread_pct = arbitrage_l_config_map.get("sell_off_spread_pct").value
+        # Position balancer - order management
+        position_balancer_refresh_interval = arbitrage_l_config_map.get("position_balancer_refresh_interval").value
+
+        # Fallbacks when importing older/partial configs (use arbitrage.pyx defaults)
         if buy_in_enabled is None:
             buy_in_enabled = True
         if buy_in_target_usdt is None:
             buy_in_target_usdt = Decimal("100")
-        if buy_in_min_profitability_val is None:
-            buy_in_min_profitability_val = Decimal("0.5")
-        buy_in_min_profitability = buy_in_min_profitability_val / Decimal("100")
+        if buy_in_spread_pct is None:
+            buy_in_spread_pct = 0.1
+        if sell_off_enabled is None:
+            sell_off_enabled = False
+        if sell_off_target_usd is None:
+            sell_off_target_usd = 1000.0
+        if sell_off_spread_pct is None:
+            sell_off_spread_pct = 0.1
+        if position_balancer_refresh_interval is None:
+            position_balancer_refresh_interval = 10.0
         # Filled order timeout (defaults to 3600 seconds = 1 hour)
         filled_order_timeout_val = arbitrage_l_config_map.get("filled_order_timeout").value
         if filled_order_timeout_val is None:
@@ -135,10 +150,16 @@ async def start(self):
             secondary_to_primary_base_conversion_rate=secondary_to_primary_base_conversion_rate,
             secondary_to_primary_quote_conversion_rate=secondary_to_primary_quote_conversion_rate,
             hb_app_notification=True,
-            # buy-in params
+            # Position balancer - buy-in configuration
             buy_in_enabled=bool(buy_in_enabled),
             buy_in_target_usd=float(buy_in_target_usdt),
-            buy_in_min_profitability=float(buy_in_min_profitability)
+            buy_in_spread_pct=float(buy_in_spread_pct),
+            # Position balancer - sell-off configuration
+            sell_off_enabled=bool(sell_off_enabled),
+            sell_off_target_usd=float(sell_off_target_usd),
+            sell_off_spread_pct=float(sell_off_spread_pct),
+            # Position balancer - order management
+            position_balancer_refresh_interval=float(position_balancer_refresh_interval)
         )
         
         self.logger().info(f"arbitrage_l started with {len(tuples)} markets and {len(market_pairs)} ordered pairs")

--- a/scripts/multi_strategy_orchestrator.py
+++ b/scripts/multi_strategy_orchestrator.py
@@ -83,9 +83,9 @@ Optimizations for 40-50 Strategies (Reconnection Performance):
    - Coordinated re-initialization after full reconnection events
    - Prevents redundant startup logic across 40-50 strategies
 
-2. Individual Strategy Buy-in:
-   - Each strategy handles its own buy-in logic in orchestrated mode
-   - Buy-in check runs when strategy first detects markets are ready
+2. Individual Strategy Position Balancing:
+   - Each strategy handles its own position balancer logic in orchestrated mode
+   - Position balancer check runs when strategy first detects markets are ready
    - No orchestrator-level coordination needed (strategies are self-contained)
 
 3. Optimized Readiness Checking:
@@ -326,10 +326,19 @@ class ArbitrageMInstanceConfig(BaseModel):
     Profitability:
       - min_profitability: 0.5 (%)
 
-    Buy-in Module (arbitrage_l uses this to acquire initial inventory):
-      - buy_in_enabled: True
-      - buy_in_target_usd: 100.0 (USD)
-      - buy_in_min_profitability: 0.5 (%)
+    Position Balancer (arbitrage_l uses this to manage inventory):
+      Buy-in (acquire assets when below target):
+        - buy_in_enabled: False
+        - buy_in_target_usd: 1000.0 (USD, minimum asset value)
+        - buy_in_spread_pct: 0.1 (%, spread below top bid for buy limit orders)
+
+      Sell-off (reduce assets when above target):
+        - sell_off_enabled: False
+        - sell_off_target_usd: 2000.0 (USD, maximum asset value)
+        - sell_off_spread_pct: 0.1 (%, spread above top ask for sell limit orders)
+
+      Order Management:
+        - position_balancer_refresh_interval: 10.0 (seconds, how often to refresh limit orders)
 
     Timing (arbitrage_l defaults):
       - status_report_interval: 60.0 (seconds)
@@ -872,10 +881,10 @@ class MultiStrategyOrchestrator(ScriptStrategyBase):
 
         This performs ONE-TIME initialization for all strategies:
         1. Log market ready status (once for all strategies)
-        2. Perform coordinated buy-in initialization (single wallet query)
+        2. Perform coordinated initialization (single wallet query)
         3. Notify strategies that markets are ready
 
-        This replaces 40-50 individual strategy readiness checks and buy-in scans.
+        This replaces 40-50 individual strategy readiness checks and position balancer scans.
         """
         self.logger().info("=" * 70)
         self.logger().info("MARKETS READY - Coordinated Initialization")
@@ -886,10 +895,9 @@ class MultiStrategyOrchestrator(ScriptStrategyBase):
             status = connector.status_dict
             self.logger().info(f"{name}: {status}")
 
-        # Buy-in coordination is handled by individual strategies in orchestrated mode
-        # Each strategy calls its own buy-in check when it first detects markets are ready
-        # arbitrage_m: calls self.c_scan_and_mark_buyin_completion()
-        # arbitrage_l: calls self._buy_in_handler.c_scan_and_mark_completion()
+        # Position balancer coordination is handled by individual strategies in orchestrated mode
+        # Each strategy calls its own position balancer check when it first detects markets are ready
+        # arbitrage_l: calls self._position_balancer.c_scan_and_mark_completion()
         # No orchestrator-level coordination needed - strategies handle it internally
 
         self.logger().info("=" * 70)
@@ -1558,9 +1566,17 @@ class MultiStrategyOrchestrator(ScriptStrategyBase):
                 'use_oracle_conversion_rate': single_config.get('use_oracle_conversion_rate', False),
                 'secondary_to_primary_base_conversion_rate': single_config.get('secondary_to_primary_base_conversion_rate', 1.0),
                 'secondary_to_primary_quote_conversion_rate': single_config.get('secondary_to_primary_quote_conversion_rate', 1.0),
+                # Position balancer - buy-in configuration
                 'buy_in_enabled': single_config.get('buy_in_enabled', False),
-                'buy_in_target_usd': single_config.get('buy_in_target_usdt', single_config.get('buy_in_target_usd', 100.0)),
-                'buy_in_min_profitability': single_config.get('buy_in_min_profitability', 0.5),
+                'buy_in_target_usd': single_config.get('buy_in_target_usdt', single_config.get('buy_in_target_usd', 1000.0)),
+                'buy_in_spread_pct': single_config.get('buy_in_spread_pct', 0.1),
+                # Position balancer - sell-off configuration (new, defaults to disabled)
+                'sell_off_enabled': single_config.get('sell_off_enabled', False),
+                'sell_off_target_usd': single_config.get('sell_off_target_usd', 2000.0),
+                'sell_off_spread_pct': single_config.get('sell_off_spread_pct', 0.1),
+                # Position balancer - order management
+                'position_balancer_refresh_interval': single_config.get('position_balancer_refresh_interval', 10.0),
+                # Timing parameters
                 'status_report_interval': single_config.get('status_report_interval', 60.0),
                 'next_trade_delay_interval': single_config.get('next_trade_delay_interval', 2.0),
                 'order_timeout': single_config.get('order_timeout', 300.0),
@@ -1858,7 +1874,7 @@ class MultiStrategyOrchestrator(ScriptStrategyBase):
                     lines.append(f"{markets_fmt} | best {r['best']}")
 
         if buyin_sections:
-            lines.append("\nBuy-in active:")
+            lines.append("\nPosition Balancer active:")
             for name, blines in buyin_sections:
                 lines.append(f"  {name}:")
                 lines.extend([f"    {ln}" for ln in blines])
@@ -2043,8 +2059,9 @@ class MultiStrategyOrchestrator(ScriptStrategyBase):
         return f"{global_base}-{global_quote} {'_'.join(parts)}"
 
     def _extract_buyin_lines(self, status_blob: str) -> List[str]:
-        """Extract the buy-in header and asset rows from a strategy status output.
-        Returns [] when buy-in is not active (no section present)."""
+        """Extract the position balancer header and asset rows from a strategy status output.
+        Returns [] when position balancer is not active (no section present).
+        Supports both old 'Buy-in:' and new 'Position Balancer:' formats."""
         if not status_blob:
             return []
         raw_lines = status_blob.split("\n")
@@ -2052,10 +2069,12 @@ class MultiStrategyOrchestrator(ScriptStrategyBase):
         collecting = False
         for raw in raw_lines:
             s = raw.strip()
-            if s.startswith("Buy-in:"):
-                # Reformat min_prof to one decimal if present
+            # Support both old "Buy-in:" and new "Position Balancer:" formats
+            if s.startswith("Buy-in:") or s.startswith("Position Balancer:"):
+                # Reformat min_prof to one decimal if present (old format compatibility)
                 try:
-                    # Example: Buy-in: target=1000.000000 min_prof=2.50%
+                    # Example old format: Buy-in: target=1000.000000 min_prof=2.50%
+                    # Example new format: Position Balancer: buy_target=1000.000000 sell_target=2000.000000
                     m = re.search(r"min_prof\s*=\s*([0-9]+(?:\.[0-9]+)?)%", s)
                     if m:
                         val = float(m.group(1))

--- a/scripts/multi_strategy_orchestrator.py
+++ b/scripts/multi_strategy_orchestrator.py
@@ -379,18 +379,38 @@ class ArbitrageMInstanceConfig(BaseModel):
         description="Conversion rate for quote asset from secondary to primary"
     )
 
-    # Buy-in configuration
+    # Position balancer configuration - Buy-in
     buy_in_enabled: bool = Field(
         default=False,
-        description="Enable buy-in module to acquire initial inventory"
+        description="Enable buy-in to acquire assets when below target"
     )
     buy_in_target_usd: float = Field(
         default=1000.0,
-        description="Target USD value for buy-in operations"
+        description="Target minimum USD value (buy when below this)"
     )
-    buy_in_min_profitability: float = Field(
-        default=1.5,
-        description="Min profitability percentage for buy-in (e.g., 0.5 for 0.5%)"
+    buy_in_spread_pct: float = Field(
+        default=0.1,
+        description="Spread percentage below top bid for buy limit orders (e.g., 0.1 = 0.1%)"
+    )
+
+    # Position balancer configuration - Sell-off
+    sell_off_enabled: bool = Field(
+        default=False,
+        description="Enable sell-off to reduce assets when above target"
+    )
+    sell_off_target_usd: float = Field(
+        default=2000.0,
+        description="Target maximum USD value (sell when above this)"
+    )
+    sell_off_spread_pct: float = Field(
+        default=0.1,
+        description="Spread percentage above top ask for sell limit orders (e.g., 0.1 = 0.1%)"
+    )
+
+    # Position balancer - Order management
+    position_balancer_refresh_interval: float = Field(
+        default=10.0,
+        description="How often to cancel and replace limit orders (seconds)"
     )
 
     # Timing parameters
@@ -731,9 +751,16 @@ class MultiStrategyOrchestrator(ScriptStrategyBase):
             "secondary_to_primary_base_conversion_rate": config.secondary_to_primary_base_conversion_rate,
             "secondary_to_primary_quote_conversion_rate": config.secondary_to_primary_quote_conversion_rate,
             "hb_app_notification": True,
+            # Position balancer - buy-in configuration
             "buy_in_enabled": config.buy_in_enabled,
             "buy_in_target_usd": config.buy_in_target_usd,
-            "buy_in_min_profitability": float(config.buy_in_min_profitability) / 100.0,
+            "buy_in_spread_pct": config.buy_in_spread_pct,
+            # Position balancer - sell-off configuration
+            "sell_off_enabled": config.sell_off_enabled,
+            "sell_off_target_usd": config.sell_off_target_usd,
+            "sell_off_spread_pct": config.sell_off_spread_pct,
+            # Position balancer - order management
+            "position_balancer_refresh_interval": config.position_balancer_refresh_interval,
             "orchestrated_mode": True,  # Enable orchestrated mode for coordinated readiness checking
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces the buy-in module with a unified PositionBalancer that supports buy and sell balancing via limit orders, adds related config options, and integrates status/controls across arbitrage_l and the multi-strategy orchestrator.
> 
> - **arbitrage_l (strategy)**:
>   - Replace `buy_in_handler` with new `PositionBalancerHandler` (`_position_balancer`) handling buy-in and sell-off before/alongside arbitrage.
>   - Hook into tick flow, readiness checks (including orchestrated mode), status output, and all order lifecycle events (completion/cancel/timeout/cleanup).
>   - Add periodic conversion-rate logging and minor maintenance tweaks.
> - **New component**:
>   - `position_balancer_handler.pxd/.pyx`: limit-order position balancing with configurable spread, target thresholds, order refresh, pending tracking, and stale-order cancellation.
> - **Config (arbitrage_l_config_map/start)**:
>   - Add fields: `buy_in_spread_pct`, `sell_off_enabled`, `sell_off_target_usd`, `sell_off_spread_pct`, `position_balancer_refresh_interval` with prompts/validators and backward-compatible fallbacks.
>   - Start flow reads new options and passes them to strategy.
> - **Multi-strategy orchestrator**:
>   - Update docs, status rendering, and config model to support Position Balancer (replace "Buy-in" references; parse new status section; new fields in `ArbitrageMInstanceConfig`; propagate to init params).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b030c6d63c042056649c39e93810416c7995da31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->